### PR TITLE
#3126: Stop using auth0 jwt nickname field, removed from the rule (an…

### DIFF
--- a/auth0/rule-return-username.js
+++ b/auth0/rule-return-username.js
@@ -5,7 +5,7 @@ function (user, context, callback) {
   });
 
   // user name
-  context.accessToken['DOMAIN_GOES_HERE/username'] = user.nickname;
+  context.accessToken['DOMAIN_GOES_HERE/username'] = user.name;
 
   // and email
   context.accessToken.custom_email = user.email;

--- a/client/src/app/UI/user-menu-panel/user-menu-panel.component.ts
+++ b/client/src/app/UI/user-menu-panel/user-menu-panel.component.ts
@@ -139,12 +139,7 @@ export class UserMenuPanelComponent implements OnInit
             return "Loading...";
         }
 
-        if(this.user.name)
-        {
-            return this.user.name;
-        }
-
-        return this.user.nickname;
+        return this.user.name;
     }
 
     get userEmail(): string

--- a/client/src/app/services/authentication.service.ts
+++ b/client/src/app/services/authentication.service.ts
@@ -257,7 +257,7 @@ export class AuthenticationService
 
         Sentry.setUser({
             id: this.getUserID(),
-            username: user.name || user.nickname,
+            username: user.name,
             email: user.email
         });
     }


### PR DESCRIPTION
…d manually updated on auth0) along with 2 places in code which was using nickname as a fallback if name not set