### PR TITLE
Mist ROI Out of Bounds PMCs Hotfix 

### DIFF
--- a/client/src/app/UI/context-image-view-widget/region-manager.ts
+++ b/client/src/app/UI/context-image-view-widget/region-manager.ts
@@ -475,7 +475,7 @@ export class RegionManager
 
         for(let locIdx of locationIndexes)
         {
-            if(this._dataset.locationPointCache[locIdx].polygon.length > 0)
+            if(this._dataset.locationPointCache[locIdx] && this._dataset.locationPointCache[locIdx].polygon.length > 0)
             {
                 result.push(new RegionDisplayPolygon(this._dataset.locationPointCache[locIdx].polygon, []));
             }

--- a/client/src/app/UI/side-panel/tabs/roi/roiitem/roiitem.component.ts
+++ b/client/src/app/UI/side-panel/tabs/roi/roiitem/roiitem.component.ts
@@ -758,7 +758,7 @@ export class ROIItemComponent implements OnInit
         return this.regionLayer.roi.mistROIItem?.ID_Depth || null;
     }
 
-    get dateAdded(): string
+    get dateAdded(): number
     {
         return this.regionLayer.roi?.dateAdded;
     }

--- a/client/src/app/models/roi.ts
+++ b/client/src/app/models/roi.ts
@@ -56,7 +56,7 @@ export class ROISavedItem
         public creator: ObjectCreator,
         public mistROIItem: MistROIItem = null,
         public visible: boolean = false,
-        public dateAdded: string = null
+        public dateAdded: number = null
     )
     {
     }

--- a/client/src/app/services/widget-region-data.service.ts
+++ b/client/src/app/services/widget-region-data.service.ts
@@ -95,7 +95,7 @@ export class RegionData extends ROISavedItem
         public shape: string,
         mistROIItem: MistROIItem = null,
         visible: boolean = false,
-        dateAdded: string = null
+        dateAdded: number = null
     )
     {
         super(id, name, locationIndexes, description, imageName, pixelIndexes, shared, creator, mistROIItem, visible, dateAdded);
@@ -345,7 +345,7 @@ export class WidgetRegionDataService
             }
             catch (error)
             {
-                let errorMsg = httpErrorToString(error, "WidgetRegionDataService.getData")
+                let errorMsg = httpErrorToString(error, "WidgetRegionDataService.getData");
                 SentryHelper.logMsg(true, errorMsg);
                 result.push(new RegionDataResultItem(null, WidgetDataErrorType.WERR_QUERY, errorMsg, null));
                 //return null;
@@ -715,7 +715,7 @@ export class WidgetRegionDataService
         ));
     }
 
-        private resubscribeViewStateROIShapes()
+    private resubscribeViewStateROIShapes()
     {
         this._viewStateRelatedSubs.add(this._viewStateService.roiShapes$.subscribe(
             (roiShapes: Map<string, string>)=>


### PR DESCRIPTION
- Adds error handling to validate the existence of a PMC before attempting to draw the corresponding polygon on the context image viewer
- Converts ROI `dateAdded` field to a number (field currently unused in UI)