### PR TITLE
Parallel Coordinates Plot Rebuild

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -42,7 +42,6 @@
         "moment": "^2.29.4",
         "ngx-dropzone": "^3.0.0",
         "papaparse": "^5.3.2",
-        "parcoord-es": "^2.2.10",
         "polygon-clipping": "^0.15.3",
         "quickhull": "^1.0.3",
         "roboto-fontface": "^0.10.0",
@@ -6998,11 +6997,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3-collection": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
-      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
-    },
     "node_modules/d3-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
@@ -7133,11 +7127,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3-format": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
-      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
-    },
     "node_modules/d3-geo": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.0.1.tgz",
@@ -7194,64 +7183,12 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3-scale": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-2.2.2.tgz",
-      "integrity": "sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==",
-      "dependencies": {
-        "d3-array": "^1.2.0",
-        "d3-collection": "1",
-        "d3-format": "1",
-        "d3-interpolate": "1",
-        "d3-time": "1",
-        "d3-time-format": "2"
-      }
-    },
-    "node_modules/d3-scale/node_modules/d3-array": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
-    },
-    "node_modules/d3-scale/node_modules/d3-color": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
-      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
-    },
-    "node_modules/d3-scale/node_modules/d3-interpolate": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
-      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
-      "dependencies": {
-        "d3-color": "1"
-      }
-    },
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/d3-shape": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
-      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
-      "dependencies": {
-        "d3-path": "1"
-      }
-    },
-    "node_modules/d3-time": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
-      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
-    },
-    "node_modules/d3-time-format": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
-      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
-      "dependencies": {
-        "d3-time": "1"
       }
     },
     "node_modules/d3-timer": {
@@ -14110,103 +14047,6 @@
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.2.tgz",
       "integrity": "sha512-6dNZu0Ki+gyV0eBsFKJhYr+MdQYAzFUGlBMNj3GNrmHxmz1lfRa24CjFObPXtjcetlOv5Ad299MhIK0znp3afw=="
     },
-    "node_modules/parcoord-es": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/parcoord-es/-/parcoord-es-2.2.10.tgz",
-      "integrity": "sha512-chFF/1Q0XuKO6PVGoOwHkXOykMn2bcTKKChFgPZZLBe3gY/bWaJNAp4tzqbCOUEhmQCRB6WsITbE4Jstbc/Yfg==",
-      "dependencies": {
-        "d3-array": "^1.2.1",
-        "d3-axis": "^1.0.8",
-        "d3-brush": "^1.0.4",
-        "d3-collection": "^1.0.4",
-        "d3-dispatch": "^1.0.3",
-        "d3-drag": "^1.2.1",
-        "d3-interpolate": "^1.2.0",
-        "d3-scale": "^2.1.0",
-        "d3-selection": "^1.3.0",
-        "d3-shape": "^1.2.0",
-        "d3-transition": "^1.1.1",
-        "requestanimationframe": "0.0.23",
-        "sylvester-es6": "0.0.2"
-      }
-    },
-    "node_modules/parcoord-es/node_modules/d3-array": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
-    },
-    "node_modules/parcoord-es/node_modules/d3-axis": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-1.0.12.tgz",
-      "integrity": "sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ=="
-    },
-    "node_modules/parcoord-es/node_modules/d3-brush": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.1.6.tgz",
-      "integrity": "sha512-7RW+w7HfMCPyZLifTz/UnJmI5kdkXtpCbombUSs8xniAyo0vIbrDzDwUJB6eJOgl9u5DQOt2TQlYumxzD1SvYA==",
-      "dependencies": {
-        "d3-dispatch": "1",
-        "d3-drag": "1",
-        "d3-interpolate": "1",
-        "d3-selection": "1",
-        "d3-transition": "1"
-      }
-    },
-    "node_modules/parcoord-es/node_modules/d3-color": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
-      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
-    },
-    "node_modules/parcoord-es/node_modules/d3-dispatch": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
-      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA=="
-    },
-    "node_modules/parcoord-es/node_modules/d3-drag": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.5.tgz",
-      "integrity": "sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==",
-      "dependencies": {
-        "d3-dispatch": "1",
-        "d3-selection": "1"
-      }
-    },
-    "node_modules/parcoord-es/node_modules/d3-ease": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
-      "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
-    },
-    "node_modules/parcoord-es/node_modules/d3-interpolate": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
-      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
-      "dependencies": {
-        "d3-color": "1"
-      }
-    },
-    "node_modules/parcoord-es/node_modules/d3-selection": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.2.tgz",
-      "integrity": "sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg=="
-    },
-    "node_modules/parcoord-es/node_modules/d3-timer": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
-      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
-    },
-    "node_modules/parcoord-es/node_modules/d3-transition": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.3.2.tgz",
-      "integrity": "sha512-sc0gRU4PFqZ47lPVHloMn9tlPcv8jxgOQg+0zjhfZXMQuvppjG6YuwdMBE0TuqCZjeJkLecku/l9R0JPcRhaDA==",
-      "dependencies": {
-        "d3-color": "1",
-        "d3-dispatch": "1",
-        "d3-ease": "1",
-        "d3-interpolate": "1",
-        "d3-selection": "^1.1.0",
-        "d3-timer": "1"
-      }
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -16936,11 +16776,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/requestanimationframe": {
-      "version": "0.0.23",
-      "resolved": "https://registry.npmjs.org/requestanimationframe/-/requestanimationframe-0.0.23.tgz",
-      "integrity": "sha1-7XmXLsCgUt+KzGuRxXUMsZ5/CQg="
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "dev": true,
@@ -18503,11 +18338,6 @@
       "dependencies": {
         "pdfkit": ">=0.8.1"
       }
-    },
-    "node_modules/sylvester-es6": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/sylvester-es6/-/sylvester-es6-0.0.2.tgz",
-      "integrity": "sha1-PmUXilrjzD9BlULZzRrVVDWRKr8="
     },
     "node_modules/symbol-observable": {
       "version": "4.0.0",
@@ -25281,11 +25111,6 @@
         "d3-path": "1 - 3"
       }
     },
-    "d3-collection": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
-      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
-    },
     "d3-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
@@ -25379,11 +25204,6 @@
         "d3-timer": "1 - 3"
       }
     },
-    "d3-format": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
-      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
-    },
     "d3-geo": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.0.1.tgz",
@@ -25425,64 +25245,10 @@
       "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
       "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="
     },
-    "d3-scale": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-2.2.2.tgz",
-      "integrity": "sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==",
-      "requires": {
-        "d3-array": "^1.2.0",
-        "d3-collection": "1",
-        "d3-format": "1",
-        "d3-interpolate": "1",
-        "d3-time": "1",
-        "d3-time-format": "2"
-      },
-      "dependencies": {
-        "d3-array": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-          "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
-        },
-        "d3-color": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
-          "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
-        },
-        "d3-interpolate": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
-          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
-          "requires": {
-            "d3-color": "1"
-          }
-        }
-      }
-    },
     "d3-selection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
-    },
-    "d3-shape": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
-      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
-      "requires": {
-        "d3-path": "1"
-      }
-    },
-    "d3-time": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
-      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
-    },
-    "d3-time-format": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
-      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
-      "requires": {
-        "d3-time": "1"
-      }
     },
     "d3-timer": {
       "version": "3.0.1",
@@ -30332,105 +30098,6 @@
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.2.tgz",
       "integrity": "sha512-6dNZu0Ki+gyV0eBsFKJhYr+MdQYAzFUGlBMNj3GNrmHxmz1lfRa24CjFObPXtjcetlOv5Ad299MhIK0znp3afw=="
     },
-    "parcoord-es": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/parcoord-es/-/parcoord-es-2.2.10.tgz",
-      "integrity": "sha512-chFF/1Q0XuKO6PVGoOwHkXOykMn2bcTKKChFgPZZLBe3gY/bWaJNAp4tzqbCOUEhmQCRB6WsITbE4Jstbc/Yfg==",
-      "requires": {
-        "d3-array": "^1.2.1",
-        "d3-axis": "^1.0.8",
-        "d3-brush": "^1.0.4",
-        "d3-collection": "^1.0.4",
-        "d3-dispatch": "^1.0.3",
-        "d3-drag": "^1.2.1",
-        "d3-interpolate": "^1.2.0",
-        "d3-scale": "^2.1.0",
-        "d3-selection": "^1.3.0",
-        "d3-shape": "^1.2.0",
-        "d3-transition": "^1.1.1",
-        "requestanimationframe": "0.0.23",
-        "sylvester-es6": "0.0.2"
-      },
-      "dependencies": {
-        "d3-array": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-          "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
-        },
-        "d3-axis": {
-          "version": "1.0.12",
-          "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-1.0.12.tgz",
-          "integrity": "sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ=="
-        },
-        "d3-brush": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.1.6.tgz",
-          "integrity": "sha512-7RW+w7HfMCPyZLifTz/UnJmI5kdkXtpCbombUSs8xniAyo0vIbrDzDwUJB6eJOgl9u5DQOt2TQlYumxzD1SvYA==",
-          "requires": {
-            "d3-dispatch": "1",
-            "d3-drag": "1",
-            "d3-interpolate": "1",
-            "d3-selection": "1",
-            "d3-transition": "1"
-          }
-        },
-        "d3-color": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
-          "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
-        },
-        "d3-dispatch": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
-          "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA=="
-        },
-        "d3-drag": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.5.tgz",
-          "integrity": "sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==",
-          "requires": {
-            "d3-dispatch": "1",
-            "d3-selection": "1"
-          }
-        },
-        "d3-ease": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
-          "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
-        },
-        "d3-interpolate": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
-          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
-          "requires": {
-            "d3-color": "1"
-          }
-        },
-        "d3-selection": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.2.tgz",
-          "integrity": "sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg=="
-        },
-        "d3-timer": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
-          "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
-        },
-        "d3-transition": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.3.2.tgz",
-          "integrity": "sha512-sc0gRU4PFqZ47lPVHloMn9tlPcv8jxgOQg+0zjhfZXMQuvppjG6YuwdMBE0TuqCZjeJkLecku/l9R0JPcRhaDA==",
-          "requires": {
-            "d3-color": "1",
-            "d3-dispatch": "1",
-            "d3-ease": "1",
-            "d3-interpolate": "1",
-            "d3-selection": "^1.1.0",
-            "d3-timer": "1"
-          }
-        }
-      }
-    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -32460,11 +32127,6 @@
         "uuid": "^3.3.2"
       }
     },
-    "requestanimationframe": {
-      "version": "0.0.23",
-      "resolved": "https://registry.npmjs.org/requestanimationframe/-/requestanimationframe-0.0.23.tgz",
-      "integrity": "sha1-7XmXLsCgUt+KzGuRxXUMsZ5/CQg="
-    },
     "require-directory": {
       "version": "2.1.1",
       "dev": true
@@ -33601,11 +33263,6 @@
       "requires": {
         "pdfkit": ">=0.8.1"
       }
-    },
-    "sylvester-es6": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/sylvester-es6/-/sylvester-es6-0.0.2.tgz",
-      "integrity": "sha1-PmUXilrjzD9BlULZzRrVVDWRKr8="
     },
     "symbol-observable": {
       "version": "4.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -47,7 +47,6 @@
     "moment": "^2.29.4",
     "ngx-dropzone": "^3.0.0",
     "papaparse": "^5.3.2",
-    "parcoord-es": "^2.2.10",
     "polygon-clipping": "^0.15.3",
     "quickhull": "^1.0.3",
     "roboto-fontface": "^0.10.0",

--- a/client/src/app/UI/atoms/expression-list/layer-settings/layer-settings.component.html
+++ b/client/src/app/UI/atoms/expression-list/layer-settings/layer-settings.component.html
@@ -114,7 +114,11 @@ POSSIBILITY OF SUCH DAMAGE.
                 (onChange)="onChangeOpacity($event)">
             </slider>
             <widget-settings-menu *ngIf="showMoreButtonVisible" [settingsDialog]="moreButtonsMenu">
-                <icon-button title="View more options" icon="assets/button-icons/three-dots.svg"></icon-button>
+                <icon-button
+                    [notificationCount]="collapsedNotificationCount"
+                    title="View more options"
+                    icon="assets/button-icons/three-dots.svg"
+                ></icon-button>
             </widget-settings-menu>
             <ng-container *ngFor="let layerButton of visibleLayerButtons">
                 <multi-state-button
@@ -143,6 +147,15 @@ POSSIBILITY OF SUCH DAMAGE.
                     icon="assets/button-icons/delete.svg"
                     (click)="onDelete()">
                 </icon-button>
+                <tag-picker
+                    *ngIf="layerButton === 'showTagPicker'"
+                    type="expression"
+                    [selectedTagIDs]="selectedTagIDs"
+                    [showCurrentTagsSection]="true"
+                    [editable]="!isSharedByOtherUser"
+                    (onTagSelectionChanged)="onTagSelectionChanged($event)"
+                >
+                </tag-picker>
                 <icon-button
                     *ngIf="layerButton === 'showDownload'"
                     title="Download this expression"
@@ -176,5 +189,4 @@ POSSIBILITY OF SUCH DAMAGE.
         <div *ngIf="createdTime > 0" class="obj-create-time">Created: {{createdTime|date:'medium'}}</div>
         <div *ngIf="expressionComments.length > 0" class="comment" title="{{expressionComments}}">{{expressionComments}}</div>
     </div>
-    <!-- <div *ngIf="expressionErrorMessage.length > 0" class="expr-error" title="{{expressionErrorMessage}}">{{expressionErrorMessage}}</div> -->
 </div>

--- a/client/src/app/UI/atoms/expression-list/layer-settings/layer-settings.component.ts
+++ b/client/src/app/UI/atoms/expression-list/layer-settings/layer-settings.component.ts
@@ -124,15 +124,11 @@ export class LayerSettingsComponent implements OnInit
     @Input() activeIcon: string;
     @Input() inactiveIcon: string;
 
-    // @Input() tags: ItemTag[] = [];
-
     @Output() visibilityChange = new EventEmitter();
     @Output() colourChange = new EventEmitter();
 
     private _isPureElement: boolean = false;
     private _expressionElement: string = "";
-
-    // selectedTagIDs: string[] = [];
 
     constructor(
         private _exprService: DataExpressionService,
@@ -176,6 +172,20 @@ export class LayerSettingsComponent implements OnInit
         }
 
         return true;
+    }
+
+    get collapsedNotificationCount(): number
+    {
+        let notificationCount = 0;
+        this.hiddenLayerButtons.forEach(button =>
+        {
+            if(button === "showTagPicker")
+            {
+                notificationCount += this.selectedTagIDs.length;
+            }
+        });
+
+        return notificationCount;
     }
 
     get labelToShow(): string

--- a/client/src/app/UI/atoms/expression-list/layer-settings/rgbmix-layer-settings.component.html
+++ b/client/src/app/UI/atoms/expression-list/layer-settings/rgbmix-layer-settings.component.html
@@ -83,7 +83,11 @@ POSSIBILITY OF SUCH DAMAGE.
 
             <div fxLayout="row" fxLayoutAlign="end center" class="gap-separated-horizontal-elements">
                 <widget-settings-menu *ngIf="showMoreButtonVisible" [settingsDialog]="moreButtonsMenu">
-                    <icon-button title="View more options" icon="assets/button-icons/three-dots.svg"></icon-button>
+                    <icon-button
+                        [notificationCount]="collapsedNotificationCount"
+                        title="View more options"
+                        icon="assets/button-icons/three-dots.svg"
+                    ></icon-button>
                 </widget-settings-menu>
                 <ng-container *ngFor="let layerButton of visibleLayerButtons">
                     <icon-button

--- a/client/src/app/UI/atoms/expression-list/layer-settings/rgbmix-layer-settings.component.ts
+++ b/client/src/app/UI/atoms/expression-list/layer-settings/rgbmix-layer-settings.component.ts
@@ -198,6 +198,20 @@ export class RGBMixLayerSettingsComponent implements OnInit
         return null;
     }
 
+    get collapsedNotificationCount(): number
+    {
+        let notificationCount = 0;
+        this.hiddenLayerButtons.forEach(button =>
+        {
+            if(button === "showTagPicker")
+            {
+                notificationCount += this.selectedTagIDs.length;
+            }
+        });
+
+        return notificationCount;
+    }
+
     get layerButtons(): string[]
     {
         let buttons: Record<string, boolean> = {

--- a/client/src/app/UI/atoms/widget-key-display/widget-key-display.component.ts
+++ b/client/src/app/UI/atoms/widget-key-display/widget-key-display.component.ts
@@ -73,8 +73,9 @@ export class WidgetKeyDisplayComponent implements OnInit
 {
     @Input() items: KeyItem[] = [];
     @Output() keyClick = new EventEmitter();
+    @Output() onToggleKey = new EventEmitter();
 
-    private _keyShowing: boolean;
+    @Input() public keyShowing: boolean = false;
 
     constructor()
     {
@@ -84,14 +85,10 @@ export class WidgetKeyDisplayComponent implements OnInit
     {
     }
 
-    get keyShowing(): boolean
-    {
-        return this._keyShowing;
-    }
-
     onToggleShowKey(): void
     {
-        this._keyShowing = !this._keyShowing;
+        this.keyShowing = !this.keyShowing;
+        this.onToggleKey.emit(this.keyShowing);
     }
 
     onClickLabel(id: string): void

--- a/client/src/app/UI/context-image-view-widget/layer-control/layer-control.component.html
+++ b/client/src/app/UI/context-image-view-widget/layer-control/layer-control.component.html
@@ -44,7 +44,14 @@ POSSIBILITY OF SUCH DAMAGE.
                 (onTagSelectionChanged)="onTagSelectionChanged($event)"
             >
             </tag-picker>
-            <mat-select multiple [(ngModel)]="filteredAuthors" class="authors-filter" placeholder="Author ...">
+            <mat-select
+                #tooltip="matTooltip"
+                [matTooltip]="authorsTooltip"
+                multiple
+                [(ngModel)]="filteredAuthors"
+                class="authors-filter"
+                placeholder="Author ..."
+            >
                 <mat-option *ngFor="let author of authors;"
                     [value]="author.user_id">{{author.name}}
                 </mat-option>

--- a/client/src/app/UI/context-image-view-widget/layer-control/layer-control.component.ts
+++ b/client/src/app/UI/context-image-view-widget/layer-control/layer-control.component.ts
@@ -569,6 +569,12 @@ export class LayerControlComponent extends ExpressionListGroupNames implements O
         this._authors = authors;
     }
 
+    get authorsTooltip(): string
+    {
+        let authorNames = this._authors.filter((author) => this._filteredAuthors.includes(author.user_id)).map((author) => author.name);
+        return this._filteredAuthors.length > 0 ? `Authors:\n${authorNames.join("\n")}` : "No Authors Selected";
+    }
+
     get filteredAuthors(): string[]
     {
         return this._filteredAuthors;

--- a/client/src/app/UI/parallel-coordinates-plot-widget/parallel-coordinates-plot-widget.component.html
+++ b/client/src/app/UI/parallel-coordinates-plot-widget/parallel-coordinates-plot-widget.component.html
@@ -45,6 +45,11 @@ POSSIBILITY OF SUCH DAMAGE.
         <push-button (onClick)="toggleAll(true)">Select All</push-button>
         <push-button (onClick)="toggleAll(false)">Deselect All</push-button>
     </div>
+
+    <div fxLayout="row" fxLayoutAlign="space-between center" class="ctrl-row gap-separated-horizontal-elements line-toggle">
+        <div class="setting-label">Lines:</div>
+        <switch-button [active]="showLines" (onToggle)="toggleLineVisibility()"></switch-button>
+    </div>
 </ng-template>
 
 
@@ -88,7 +93,7 @@ POSSIBILITY OF SUCH DAMAGE.
                     </div>
                 </div>
             </div>
-            <svg width="100%" height="calc(100% - 14px - 12px - 12px)" class="line-container">
+            <svg width="100%" height="calc(100% - 14px - 12px - 12px)" class="line-container" *ngIf="showLines">
                 <g *ngFor="let point of data">
                     <line
                         *ngFor="let line of point.lines" 

--- a/client/src/app/UI/parallel-coordinates-plot-widget/parallel-coordinates-plot-widget.component.html
+++ b/client/src/app/UI/parallel-coordinates-plot-widget/parallel-coordinates-plot-widget.component.html
@@ -41,7 +41,7 @@ POSSIBILITY OF SUCH DAMAGE.
             </div>
         </div>
     </div>
-    <div class="selection-container" fxLayout="row" fxLayoutAlign="space-between center">
+    <div class="selection-container" fxLayout="row" fxLayoutAlign="space-evenly center">
         <push-button (onClick)="toggleAll(true)">Select All</push-button>
         <push-button (onClick)="toggleAll(false)">Deselect All</push-button>
     </div>

--- a/client/src/app/UI/parallel-coordinates-plot-widget/parallel-coordinates-plot-widget.component.html
+++ b/client/src/app/UI/parallel-coordinates-plot-widget/parallel-coordinates-plot-widget.component.html
@@ -57,6 +57,7 @@ POSSIBILITY OF SUCH DAMAGE.
     <div fxLayout="row" fxLayoutAlign="space-between center" class="panel-title">
         <widget-switcher [activeSelector]='thisSelector' [widgetPosition]='widgetPosition'></widget-switcher>
         <push-button (onClick)="onRegions($event)" title="Choose RGBU regions to display" class="regions-btn">Regions</push-button>
+        <push-button (onClick)="toggleKey()" title="Toggle Key" class="key-btn">Key</push-button>
         <widget-settings-menu [settingsDialog]="selectionSettingsMenu">
             <icon-button title='Show Settings Menu' icon="assets/button-icons/settings.svg">
             </icon-button>
@@ -111,4 +112,12 @@ POSSIBILITY OF SUCH DAMAGE.
 
         </div>
     </div>
+    <widget-key-display 
+        *ngIf="keyShowing"
+        [keyShowing]="keyShowing"
+        (onToggleKey)="toggleKey()"
+        [items]="keyItems"
+        class="key-location-top-right-below-title"
+    >
+    </widget-key-display>
 </div>

--- a/client/src/app/UI/parallel-coordinates-plot-widget/parallel-coordinates-plot-widget.component.html
+++ b/client/src/app/UI/parallel-coordinates-plot-widget/parallel-coordinates-plot-widget.component.html
@@ -32,7 +32,7 @@ POSSIBILITY OF SUCH DAMAGE.
 <ng-template #selectionSettingsMenu>
     <div fxLayout="column" class="gap-separated-vertical-elements" *ngIf="dimensions">
         <div>
-            <div *ngFor="let axis of axes">
+            <div *ngFor="let axis of axes" class="axis-toggle">
                 <div fxLayout="row" fxLayoutAlign="space-between center"
                     class="ctrl-row gap-separated-horizontal-elements">
                     <div class="setting-label">{{axis.title}}:</div>
@@ -41,26 +41,69 @@ POSSIBILITY OF SUCH DAMAGE.
             </div>
         </div>
     </div>
+    <div class="selection-container" fxLayout="row" fxLayoutAlign="space-between center">
+        <push-button (onClick)="toggleAll(true)">Select All</push-button>
+        <push-button (onClick)="toggleAll(false)">Deselect All</push-button>
+    </div>
 </ng-template>
 
 
 <div fxLayout="column" class="panel outer-panel" fxFill>
     <div fxLayout="row" fxLayoutAlign="space-between center" class="panel-title">
         <widget-switcher [activeSelector]='thisSelector' [widgetPosition]='widgetPosition'></widget-switcher>
-        <push-button title="Load All Points" (onClick)="loadPoints()" [disabled]="isSelectionLoaded"
-            class="load-points">Load
-            {{selectionCountText}} Points
-        </push-button>
-        <push-button [disabled]="!isHighlighted" (onClick)="convertToSelection()"
-            title="Convert PCP Selection to Global Selection" class="convert-selection">Convert To Selection
-            ({{highlightedCount}})
-        </push-button>
+        <push-button (onClick)="onRegions($event)" title="Choose RGBU regions to display" class="regions-btn">Regions</push-button>
         <widget-settings-menu [settingsDialog]="selectionSettingsMenu">
             <icon-button title='Show Settings Menu' icon="assets/button-icons/settings.svg">
             </icon-button>
         </widget-settings-menu>
     </div>
     <div style="width: 100%; height: 100%; background: black; position: relative;">
-        <div style="width: 100%; height: calc(100% - 30px);" id="parallel-coords-{{widgetPosition}}"></div>
+        <div style="width: 100%; height: calc(100% - 10px);" id="parallel-coords-{{widgetPosition}}" class="pcp-plot">
+            <div class="axes">
+                <div *ngFor="let axis of visibleAxes" class="axis-container">
+                    <div class="axis-title">{{axis.title}}</div>
+                    <div class="tick-container">
+                        <div class="tick"></div>
+                        <div class="tick-label">{{axis.max|number:'1.0-2'}}</div>
+                    </div>
+                    <div class="axis-line">
+                        <div class="point-container">
+                            <div *ngFor="let point of data" class="point-tick-container"
+                                [style.top]="getFormattedValueAsPercentage(point, axis)">
+                                <div class="inner-tick"></div>
+                                <div 
+                                    class="inner-point" 
+                                    style.background="rgb({{point.color}})" 
+                                    #tooltip="matTooltip" 
+                                    [matTooltip]="point.tooltipText"
+                                >
+                                </div>
+                                <div class="tick-label">{{point[axis.key]|number:'1.0-2'}}</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="tick-container">
+                        <div class="tick"></div>
+                        <div class="tick-label">{{axis.min|number:'1.0-2'}}</div>
+                    </div>
+                </div>
+            </div>
+            <svg width="100%" height="calc(100% - 14px - 12px - 12px)" class="line-container">
+                <g *ngFor="let point of data">
+                    <line
+                        *ngFor="let line of point.lines" 
+                        #tooltip="matTooltip" 
+                        [matTooltip]="point.tooltipText"
+                        [attr.x1]="line.xStart"
+                        [attr.y1]="line.yStart" 
+                        [attr.x2]="line.xEnd" 
+                        [attr.y2]="line.yEnd"
+                        attr.stroke="rgb({{point.color}})"
+                        stroke-width="3px"
+                    />
+                </g>
+            </svg>
+
+        </div>
     </div>
 </div>

--- a/client/src/app/UI/parallel-coordinates-plot-widget/parallel-coordinates-plot-widget.component.scss
+++ b/client/src/app/UI/parallel-coordinates-plot-widget/parallel-coordinates-plot-widget.component.scss
@@ -43,6 +43,10 @@
     margin: 4px 0;
 }
 
+.line-toggle {
+    margin-top: $sz-unit;
+}
+
 .selection-container {
     margin-top: $sz-unit;
 }

--- a/client/src/app/UI/parallel-coordinates-plot-widget/parallel-coordinates-plot-widget.component.scss
+++ b/client/src/app/UI/parallel-coordinates-plot-widget/parallel-coordinates-plot-widget.component.scss
@@ -31,7 +31,15 @@
 
 .regions-btn {
     margin-left: auto;
-    margin-right: 5px;
+    margin-right: 4px;
+}
+
+widget-key-display {
+    z-index: 101;
+}
+
+.key-btn {
+    margin-right: 4px;
 }
 
 ::ng-deep .mat-tooltip  {

--- a/client/src/app/UI/parallel-coordinates-plot-widget/parallel-coordinates-plot-widget.component.scss
+++ b/client/src/app/UI/parallel-coordinates-plot-widget/parallel-coordinates-plot-widget.component.scss
@@ -27,11 +27,113 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-.load-points {
+@import 'variables.scss';
+
+.regions-btn {
     margin-left: auto;
     margin-right: 5px;
 }
 
-.convert-selection {
-    margin-right: 5px;
+::ng-deep .mat-tooltip  {
+  white-space: pre-line !important;
+  background-color: #2B3136;
+}
+
+.axis-toggle {
+    margin: 4px 0;
+}
+
+.selection-container {
+    margin-top: $sz-unit;
+}
+
+.axes {
+    display: flex;
+    justify-content: space-between;
+    height: 100%;
+
+    .axis-container {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+
+        .axis-title {
+            font-size: 12px;
+            padding: 8px;
+            padding-bottom: 2px;
+            color: $clr-gray-30;
+        }
+
+        .axis-line {
+            width: 1px;
+            height: 100%;
+            background: $clr-gray-60;
+            position: relative;
+            z-index: 100;
+
+            .point-container {
+                position: absolute;
+                width: 1px;
+                height: calc(100% - 14px);
+            }
+        }
+
+        .tick-container {
+            position: relative;
+
+            .tick {
+                width: 20px;
+                height: 1px;
+                background: $clr-gray-60;
+            }
+
+            .tick-label {
+                font-size: 10px;
+                position: absolute;
+                top: -6.5px;
+                left: 22px;
+                color: $clr-gray-60;
+                text-shadow: 1px 1px 2px black;
+            }
+        }
+
+        .point-tick-container {
+            position: absolute;
+            display: flex;
+            align-items: center;
+
+            .inner-tick {
+                width: 5px;
+                height: 1px;
+                background: $clr-gray-60;
+            }
+
+            .inner-point {
+                width: 6px;
+                height: 6px;
+                position: absolute;
+                left: -3px;
+                border-radius: 50%;
+            }
+
+            .tick-label {
+                margin-left: 2px;
+                font-size: 10px;
+                color: white;
+                text-shadow: 0px 0px 3px black;
+
+                z-index: 100;
+            }
+        }
+    }
+}
+
+.pcp-plot {
+    position: relative;
+
+    .line-container {
+        position: absolute;
+        top: 31px;
+    }
 }

--- a/client/src/app/UI/parallel-coordinates-plot-widget/parallel-coordinates-plot-widget.component.scss
+++ b/client/src/app/UI/parallel-coordinates-plot-widget/parallel-coordinates-plot-widget.component.scss
@@ -42,11 +42,6 @@ widget-key-display {
     margin-right: 4px;
 }
 
-::ng-deep .mat-tooltip  {
-  white-space: pre-line !important;
-  background-color: #2B3136;
-}
-
 .axis-toggle {
     margin: 4px 0;
 }

--- a/client/src/app/UI/rgbuplot/rgbuplot.component.ts
+++ b/client/src/app/UI/rgbuplot/rgbuplot.component.ts
@@ -50,17 +50,6 @@ import { RGBUPlotInteraction } from "./interaction";
 import { RGBUPlotModel } from "./model";
 import { RGBUAxisUnit, RGBUMineralPoint, RGBUPlotData, RGBURatioPoint } from "./rgbu-data";
 
-
-
-
-
-
-
-
-
-
-
-
 @Component({
     selector: "rgbu-plot",
     templateUrl: "./rgbuplot.component.html",
@@ -247,6 +236,7 @@ export class RGBUPlotComponent implements OnInit, OnDestroy, AfterViewInit
 
     ngAfterViewInit(): void
     {
+        this.prepareData("init");
         this.onResize();
     }
 
@@ -433,7 +423,7 @@ export class RGBUPlotComponent implements OnInit, OnDestroy, AfterViewInit
 
         let t6 = performance.now();
 
-        //console.log("  RGBUPlot calcPoints took: "+(t1-t0).toLocaleString()+"ms+"+(t2-t1).toLocaleString()+"ms+"+(t3-t2).toLocaleString()+"ms+"+(t4-t3).toLocaleString()+"ms+"+(t5-t4).toLocaleString()+"ms+"+(t6-t5).toLocaleString()+"ms. Total="+(t6-t0).toLocaleString()+"ms");
+        console.log("  RGBUPlot calcPoints took: "+(t1-t0).toLocaleString()+"ms+"+(t2-t1).toLocaleString()+"ms+"+(t3-t2).toLocaleString()+"ms+"+(t4-t3).toLocaleString()+"ms+"+(t5-t4).toLocaleString()+"ms+"+(t6-t5).toLocaleString()+"ms. Total="+(t6-t0).toLocaleString()+"ms");
 
         return rgbuPlotData;
     }

--- a/client/src/app/UI/side-panel/side-panel.component.ts
+++ b/client/src/app/UI/side-panel/side-panel.component.ts
@@ -31,7 +31,6 @@ import { Component, ComponentFactoryResolver, ComponentRef, OnInit, ViewChild, V
 import { rgbuPlotWidgetState, ViewStateService } from "src/app/services/view-state.service";
 import { IconButtonState } from "src/app/UI/atoms/buttons/icon-button/icon-button.component";
 import { QuantificationCombineComponent } from "src/app/UI/side-panel/tabs/quantification-combine/quantification-combine.component";
-import { environment } from "src/environments/environment";
 import { DiffractionComponent } from "./tabs/diffraction/diffraction.component";
 import { ROIComponent } from "./tabs/roi/roi.component";
 import { MistROIComponent } from "./tabs/mist-roi/mist-roi.component";
@@ -58,6 +57,7 @@ export class SidePanelComponent implements OnInit
     private _CollectionsTab: string = "Collections";
     private _ROITab: string = "Regions of Interest";
     private _MistROITab: string = "MIST ROIs";
+    private _SelectionTab: string = "Selection";
     private _DiffractionTab: string = "Diffraction";
     private _RoughnessTab: string = "Roughness";
     private _MultiQuantTab: string = "Multi-Quant";
@@ -70,7 +70,7 @@ export class SidePanelComponent implements OnInit
         this._CollectionsTab,
         this._ROITab,
         this._MistROITab,
-        "Selection",
+        this._SelectionTab,
         this._DiffractionTab,
         this._RoughnessTab,
         //"Drift Correction"
@@ -291,7 +291,7 @@ export class SidePanelComponent implements OnInit
 
     onOpenView(shortcut: string): void
     {
-        if(shortcut==="RGBU View")
+        if(shortcut === "RGBU View")
         {
             // Show RGBU Plot in the underspectrum0 spot and display UV/Blue and UV/IR
             this._viewStateService.setAnalysisViewSelector("underspectrum0", ViewStateService.widgetSelectorRGBUPlot);

--- a/client/src/app/UI/side-panel/tabs/selection/selection.component.html
+++ b/client/src/app/UI/side-panel/tabs/selection/selection.component.html
@@ -67,7 +67,7 @@ POSSIBILITY OF SUCH DAMAGE.
                         fxLayoutAlign="space-between center"
                         class="average-rgbu-ratio">
                         <span class="ratio-title">{{averageRGBURatio.name}}</span>
-                        <span class="ratio-value">{{averageRGBURatio.ratio}}</span>
+                        <span class="ratio-value">{{averageRGBURatio.ratio|number:'1.0-2'}}</span>
                     </div>
                 </div>
             </cdk-accordion-item>

--- a/client/src/app/UI/tag-picker/tag-picker.component.html
+++ b/client/src/app/UI/tag-picker/tag-picker.component.html
@@ -107,7 +107,9 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
 </ng-template>
 <widget-settings-menu [settingsDialog]="tagMenu" class="tag-button" [openDirDown]="false" (onClose)="onClose()">
-    <icon-button 
+    <icon-button
+        #tooltip="matTooltip"
+        [matTooltip]="selectedTagsTooltip"
         icon="assets/button-icons/tag.svg"
         [notificationCount]="tagCount"
         (click)="delayedFocusOnInput()"

--- a/client/src/app/UI/tag-picker/tag-picker.component.ts
+++ b/client/src/app/UI/tag-picker/tag-picker.component.ts
@@ -99,6 +99,11 @@ export class TagPickerComponent implements OnInit
         return this.selectedTags.length;
     }
 
+    get selectedTagsTooltip(): string
+    {
+        return this.selectedTags.length > 0 ? `Tags:\n${this.selectedTags.map(tag => tag.name).join("\n")}` : "No tags selected";
+    }
+
     get tagSearchValue(): string
     {
         return this._tagSearchValue;

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -31,9 +31,9 @@ import { BrowserModule, Title } from "@angular/platform-browser";
 import { NgModule, ErrorHandler, Injectable, APP_INITIALIZER } from "@angular/core";
 import { HTTP_INTERCEPTORS, HttpErrorResponse, HttpClientModule } from "@angular/common/http";
 import { FormsModule } from "@angular/forms";
-import { MAT_DIALOG_DEFAULT_OPTIONS } from "@angular/material/dialog";
+import { MAT_DIALOG_DEFAULT_OPTIONS,  MatDialogRef, MAT_DIALOG_DATA } from "@angular/material/dialog";
+import { MatTooltipModule } from "@angular/material/tooltip";
 import { OverlayModule } from "@angular/cdk/overlay";
-import { MatDialogRef, MAT_DIALOG_DATA } from "@angular/material/dialog";
 import { CdkAccordionModule } from "@angular/cdk/accordion";
 import { DragDropModule } from "@angular/cdk/drag-drop";
 
@@ -463,7 +463,7 @@ const appInitializerFn = (configService: EnvConfigurationInitService)=>
         AddBearerPipe,
         AddDatasetDialogComponent,
         LogViewerComponent,
-        PlotExporterDialogComponent
+        PlotExporterDialogComponent,
     ],
     imports: [
         BrowserModule,
@@ -479,6 +479,7 @@ const appInitializerFn = (configService: EnvConfigurationInitService)=>
         CodemirrorModule,
         NgxDropzoneModule,
         DragDropModule,
+        MatTooltipModule,
     ],
     providers: [
         EnvConfigurationInitService,

--- a/client/src/app/services/view-state.service.ts
+++ b/client/src/app/services/view-state.service.ts
@@ -336,7 +336,8 @@ export class rgbuImagesWidgetState
 export class parallelogramWidgetState
 {
     constructor(
-        public colourChannels: string[]
+        public regions: string[],
+        public channels: string[],
     )
     {
     }

--- a/client/src/scss/atoms.scss
+++ b/client/src/scss/atoms.scss
@@ -208,7 +208,7 @@ TODO: get this working... no time at time of writing
 }
 
 .unit-padding {
-    padding: $sz-unit;
+    padding: $sz-unit !important;
 }
 
 .setting-row-no-pad {

--- a/client/src/scss/atoms.scss
+++ b/client/src/scss/atoms.scss
@@ -311,3 +311,9 @@ nav > a + a {
     right: -6px;
     top: -6px;
 }
+
+::ng-deep .mat-tooltip  {
+  white-space: pre-line !important;
+  background-color: #2B3136;
+  box-shadow: 0 0 2px black;
+}


### PR DESCRIPTION
- Entirely rebuilds parallel coordinates plot from scratch and removes parcoords-es dependency
  - Changes plot to use averages of ROIs, dataset, and active selection instead of visualizing every pixel
  - Adds region selection and ability to toggle lines
  - Adds tooltips
- Updates selection side panel tab to match PCP values and default shows averages for entire dataset if no selection is active
- Fixes bug with RGBU plot resetting on widget change (Was only preparing data on subscription change, but a widget/layout change forces a refresh that doesn't update the subscriptions)
- Adds tooltips to tag picker and author filter
- Adds notification count to "more buttons" button in expressions panel