### PR TITLE
Expression Save and Apply Inconsistencies

### DIFF
--- a/client/src/app/UI/atoms/expression-list/expression-list.component.html
+++ b/client/src/app/UI/atoms/expression-list/expression-list.component.html
@@ -121,6 +121,7 @@ POSSIBILITY OF SUCH DAMAGE.
                     [activeIcon]="selectedIcon"
                     [inactiveIcon]="unselectedIcon"
                     (visibilityChange)="onLayerVisibilityChange($event)"
+                    (onLayerImmediateSelection)="onLayerImmediateSelectionEvent($event)"
                     (colourChange)="onLayerColourChange($event)">
                 </context-layer-settings>
             </ng-container>

--- a/client/src/app/UI/atoms/expression-list/expression-list.component.ts
+++ b/client/src/app/UI/atoms/expression-list/expression-list.component.ts
@@ -69,6 +69,7 @@ export class ExpressionListComponent extends ExpressionListGroupNames implements
 
     @Output() headerSectionToggle = new EventEmitter();
     @Output() visibilityChange = new EventEmitter();
+    @Output() onLayerImmediateSelection = new EventEmitter();
     @Output() colourChange = new EventEmitter();
 
     stickyItemHeaderName: string = "";
@@ -171,6 +172,12 @@ export class ExpressionListComponent extends ExpressionListGroupNames implements
         {
             this._rgbMixService.setExploratoryRGBMix(event.red, event.green, event.blue, event.visible);
         }
+    }
+
+    // Shortcut to select and propogate an immediate "apply" event up to parent for current layer
+    onLayerImmediateSelectionEvent(event: LayerVisibilityChange): void
+    {
+        this.onLayerImmediateSelection.emit(event);
     }
 
     // Layer visibility, we pass this through to our owner, as it may need to be processed a certain way

--- a/client/src/app/UI/atoms/expression-list/layer-settings/layer-settings.component.ts
+++ b/client/src/app/UI/atoms/expression-list/layer-settings/layer-settings.component.ts
@@ -125,6 +125,7 @@ export class LayerSettingsComponent implements OnInit
     @Input() inactiveIcon: string;
 
     @Output() visibilityChange = new EventEmitter();
+    @Output() onLayerImmediateSelection = new EventEmitter();
     @Output() colourChange = new EventEmitter();
 
     private _isPureElement: boolean = false;
@@ -452,6 +453,12 @@ export class LayerSettingsComponent implements OnInit
                     this._exprService.edit(this.layerInfo.layer.id, dlgResult.expr.name, dlgResult.expr.expression, toEdit.type, dlgResult.expr.comments).subscribe(
                         ()=>
                         {
+                            if(dlgResult.applyNow)
+                            {
+                                let visibilityChange = new LayerVisibilityChange(this.layerInfo.layer.id, true, this.layerInfo.layer.opacity, []);
+                                this.visibilityChange.emit(visibilityChange);
+                                this.onLayerImmediateSelection.emit(visibilityChange);
+                            }
                             // Don't need to do anything, service refreshes
                         },
                         (err)=>

--- a/client/src/app/UI/expression-editor/expression-editor.component.html
+++ b/client/src/app/UI/expression-editor/expression-editor.component.html
@@ -58,7 +58,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
     <div fxLayout="row" fxLayoutAlign="end" class="choice-container gap-separated-horizontal-elements">
         <push-button buttonStyle="outline" (onClick)="onCancel()">Cancel</push-button>
-        <push-button buttonStyle="outline" [disabled]="!isEditable" (onClick)="onApplyToChart()">Save and Apply to Chart</push-button>
+        <push-button *ngIf="data.isImmediatelyAppliable" buttonStyle="outline" [disabled]="!isEditable" (onClick)="onApplyToChart()">Save and Apply to Chart</push-button>
         <push-button buttonStyle="yellow" [disabled]="!isEditable" (onClick)="onOK()">Apply</push-button>
     </div>
 </div>

--- a/client/src/app/UI/expression-editor/expression-editor.component.ts
+++ b/client/src/app/UI/expression-editor/expression-editor.component.ts
@@ -45,7 +45,8 @@ export class ExpressionEditorConfig
     constructor(
         public expr: DataExpression,
         public allowEdit: boolean,
-        public applyNow: boolean = false
+        public applyNow: boolean = false,
+        public isImmediatelyAppliable: boolean = true,
     )
     {
     }

--- a/client/src/app/UI/expression-picker/expression-picker.component.html
+++ b/client/src/app/UI/expression-picker/expression-picker.component.html
@@ -49,6 +49,7 @@ POSSIBILITY OF SUCH DAMAGE.
         [initialScrollToIdx]="initialScrollToIdx"
         (headerSectionToggle)="onToggleLayerSectionOpen($event)"
         (visibilityChange)="onLayerVisibilityChange($event)"
+        (onLayerImmediateSelection)="onLayerImmediateSelection($event)"
         fxFlex="100%">
         <!-- NOTE: we don't listen for layer colour change as we don't show the colour picker -->
 

--- a/client/src/app/UI/expression-picker/expression-picker.component.ts
+++ b/client/src/app/UI/expression-picker/expression-picker.component.ts
@@ -220,6 +220,12 @@ export class ExpressionPickerComponent extends ExpressionListGroupNames implemen
         this.regenerateItemList();
     }
 
+    onLayerImmediateSelection(event: LayerVisibilityChange): void
+    {
+        this.onLayerVisibilityChange(event);
+        this.onOK();
+    }
+
     onLayerVisibilityChange(event: LayerVisibilityChange): void
     {
         // We handle this by saving the ID in our list of "active" ids, if it's marked visible...

--- a/client/src/app/UI/spectrum-chart-widget/tools/range-select.ts
+++ b/client/src/app/UI/spectrum-chart-widget/tools/range-select.ts
@@ -159,38 +159,29 @@ export class RangeSelect extends BaseSpectrumTool
         const dialogConfig = new MatDialogConfig();
         dialogConfig.panelClass = "panel";
         dialogConfig.disableClose = true;
-        //dialogConfig.backdropClass = "panel";
 
         let toEdit = this._ctx.expressionService.getExpression(expressionID);
 
-        // We only allow editing if we were allowed to, AND if expression is NOT shared AND if it was created by our user
-        dialogConfig.data = new ExpressionEditorConfig(toEdit, true);
+        dialogConfig.data = new ExpressionEditorConfig(toEdit, true, false, false);
 
         const dialogRef = this.dialog.open(ExpressionEditorComponent, dialogConfig);
 
         dialogRef.afterClosed().subscribe(
             (dlgResult: ExpressionEditorConfig)=>
             {
-                if(!dlgResult)
-                {
-                    // User probably cancelled
-                }
-                else
+                if(dlgResult)
                 {
                     let expr = new DataExpression(toEdit.id, dlgResult.expr.name, dlgResult.expr.expression, toEdit.type, dlgResult.expr.comments, toEdit.shared, toEdit.creator, toEdit.createUnixTimeSec, toEdit.modUnixTimeSec);
                     this._ctx.expressionService.edit(expressionID, dlgResult.expr.name, dlgResult.expr.expression, toEdit.type, dlgResult.expr.comments).subscribe(
+                        ()=> null,
                         ()=>
-                        {
-                            // Don't need to do anything, service refreshes
-                        },
-                        (err)=>
                         {
                             alert("Failed to save edit data expression: "+expr.name);
                         }
                     );
                 }
             },
-            (err)=>
+            ()=>
             {
                 alert("Error while editing data expression: "+toEdit.name);
             }


### PR DESCRIPTION
## Currently
- Clicking the edit expression button from the expression picker modal and then clicking "save and apply" just selects the expression in the list and does not apply it
  - Creating a new expression from the expression picker modal and clicking "save and apply" both selects and applies it
- Clicking "save and apply" from the context image layers panel just saves it and does nothing different
- Clicking "save and apply" from the spectrum chart "take me there" range expression creation shortcut just saves it

## Changes
- Immediately applies edited expression to visualization instead of just selecting it in expression picker
- Makes expression "save and apply" button turn on visibility for both edited and new expressions from the context image layers panel
- Hides "save and apply" from spectrum range shortcut as this is a parentless shortcut