### PR TITLE
Active ROI Ordering

### DIFF
--- a/client/src/app/UI/roipicker/roipicker.component.html
+++ b/client/src/app/UI/roipicker/roipicker.component.html
@@ -78,6 +78,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
     <div fxLayout="row" fxLayoutAlign="end center" class="card-toolbar gap-separated-horizontal-elements">
         <push-button buttonStyle='outline' (onClick)="onCancel()">Cancel</push-button>
+        <push-button buttonStyle='outline' (onClick)="onClear()">Clear</push-button>
         <push-button buttonStyle='yellow' (onClick)="onOK()">Apply</push-button>
     </div>
 </div>

--- a/client/src/app/UI/roipicker/roipicker.component.ts
+++ b/client/src/app/UI/roipicker/roipicker.component.ts
@@ -182,6 +182,19 @@ export class ROIPickerComponent implements OnInit
 
                 this.userROIs.sort((a, b) => (a.label.localeCompare(b.label)));
                 this.sharedROIs.sort((a, b) => (a.label.localeCompare(b.label)));
+
+                // Sort enabled ROIS to the top for easier access
+                let enabledUserROIs = this.userROIs.filter((roi) => roi.active);
+                let enabledSharedROIs = this.sharedROIs.filter((roi) => roi.active);
+                let enabledMISTROIs = this.mistROIs.filter((roi) => roi.active);
+
+                let disabledUserROIs = this.userROIs.filter((roi) => !roi.active);
+                let disabledSharedROIs = this.sharedROIs.filter((roi) => !roi.active);
+                let disabledMISTROIs = this.mistROIs.filter((roi) => !roi.active);
+
+                this.userROIs = enabledUserROIs.concat(disabledUserROIs);
+                this.sharedROIs = enabledSharedROIs.concat(disabledSharedROIs);
+                this.mistROIs = enabledMISTROIs.concat(disabledMISTROIs);
             },
             (err)=>
             {

--- a/client/src/app/UI/roipicker/roipicker.component.ts
+++ b/client/src/app/UI/roipicker/roipicker.component.ts
@@ -298,4 +298,13 @@ export class ROIPickerComponent implements OnInit
     {
         this.dialogRef.close(null);
     }
+
+    onClear()
+    {
+        let rois = this.getAllROIs();
+        rois.forEach((roi) =>
+        {
+            roi.active = false;
+        });
+    }
 }

--- a/client/src/app/UI/spectrum-chart-widget/spectrum-region-picker/spectrum-region-picker.component.html
+++ b/client/src/app/UI/spectrum-chart-widget/spectrum-region-picker/spectrum-region-picker.component.html
@@ -38,12 +38,16 @@ POSSIBILITY OF SUCH DAMAGE.
             *ngFor="let source of predefinedSources"
             [source]="source">
         </spectrum-region-settings>
-        <div *ngIf="userSources.length > 0" class="list-subheading">User Regions</div>
+        <div *ngIf="userSources.length > 0" class="list-subheading clearable-heading">User Regions 
+            <push-button buttonStyle="outline" (onClick)="onClear(userSources)">Clear</push-button>
+        </div>
         <spectrum-region-settings
             *ngFor="let source of userSources"
             [source]="source">
         </spectrum-region-settings>
-        <div *ngIf="sharedSources.length > 0" class="list-subheading">Shared Regions</div>
+        <div *ngIf="sharedSources.length > 0" class="list-subheading">Shared Regions
+            <push-button buttonStyle="outline" (onClick)="onClear(sharedSources)">Clear</push-button>
+        </div>
         <spectrum-region-settings
             *ngFor="let source of sharedSources"
             [source]="source">

--- a/client/src/app/UI/spectrum-chart-widget/spectrum-region-picker/spectrum-region-picker.component.scss
+++ b/client/src/app/UI/spectrum-chart-widget/spectrum-region-picker/spectrum-region-picker.component.scss
@@ -33,3 +33,12 @@
 .scrollable-container {
     overflow-y: scroll;
 }
+
+.clearable-heading {
+    display: flex;
+    align-items: center;
+
+    push-button {
+        margin-left: auto;
+    }
+}

--- a/client/src/app/UI/spectrum-chart-widget/spectrum-region-picker/spectrum-region-picker.component.ts
+++ b/client/src/app/UI/spectrum-chart-widget/spectrum-region-picker/spectrum-region-picker.component.ts
@@ -96,6 +96,16 @@ export class SpectrumRegionPickerComponent implements OnInit
 
                 this.userSources.sort((a: SpectrumSource, b: SpectrumSource)=>(a.roiName.localeCompare(b.roiName)));
                 this.sharedSources.sort((a: SpectrumSource, b: SpectrumSource)=>(a.roiName.localeCompare(b.roiName)));
+
+                let enabledUserSources = this.userSources.filter((source) => source.lineChoices.some((choice) => choice.enabled));
+                let enabledSharedSources = this.sharedSources.filter((source) => source.lineChoices.some((choice) => choice.enabled));
+
+                let disabledUserSources = this.userSources.filter((source) => !source.lineChoices.some((choice) => choice.enabled));
+                let disabledSharedSources = this.sharedSources.filter((source) => !source.lineChoices.some((choice) => choice.enabled));
+
+                // Move enabled sources to the top of the list
+                this.userSources = enabledUserSources.concat(disabledUserSources);
+                this.sharedSources = enabledSharedSources.concat(disabledSharedSources);
             },
             (err)=>
             {

--- a/client/src/app/UI/spectrum-chart-widget/spectrum-region-picker/spectrum-region-picker.component.ts
+++ b/client/src/app/UI/spectrum-chart-widget/spectrum-region-picker/spectrum-region-picker.component.ts
@@ -107,4 +107,16 @@ export class SpectrumRegionPickerComponent implements OnInit
     {
         this._subs.unsubscribe();
     }
+
+    onClear(sources: SpectrumSource[]): void
+    {
+        sources.forEach((source) => 
+        {
+            source.lineChoices.forEach(choice =>
+            {
+                choice.enabled = false;
+                this._spectrumService.mdl.removeSpectrumLine(source.roiID, choice.lineExpression);
+            });
+        });
+    }
 }


### PR DESCRIPTION
- Adds a "clear" button to ROI Picker Dialog and to Spectrum Region Picker
  - Clear button is per section for region picker and global for regular ROI Picker
- Sorts active ROIs to top of respective list (while maintaining alphanumeric order) 