### PR TITLE
Fixes Hidden Character Bug in Expression Editor

### DIFF
--- a/client/src/app/UI/expression-editor/expression-editor.component.ts
+++ b/client/src/app/UI/expression-editor/expression-editor.component.ts
@@ -105,8 +105,7 @@ export class ExpressionEditorComponent implements OnInit, OnDestroy
         this.dialogRef.afterOpened().subscribe(
             ()=>
             {
-                //let cm = this._codeMirror.codeMirror;
-                //cm.refresh();
+                this._codeMirror.codeMirror.refresh();
             }
         );
     }


### PR DESCRIPTION
- Adds back refresh after modal is opened, which fixes bug where the line count side panel covers the first character on expression edit