### PR TITLE
Feature/pcp minerals

### DIFF
--- a/client/src/app/UI/atoms/expression-list/expression-list.component.ts
+++ b/client/src/app/UI/atoms/expression-list/expression-list.component.ts
@@ -226,6 +226,7 @@ export class ExpressionListComponent extends ExpressionListGroupNames implements
     {
         let lastHeaderIndex = 0;
         let activeHeader: LayerViewItem = null;
+        let activeHeaderIndex = 0;
         if(currentScrollPosition < this.itemSize)
         {
             // If we're at the top, don't show a sticky header
@@ -243,10 +244,35 @@ export class ExpressionListComponent extends ExpressionListGroupNames implements
                 if(endPosition - startPosition > this.itemSize && currentScrollPosition >= startPosition && currentScrollPosition < endPosition)
                 {
                     activeHeader = this.items.items[lastHeaderIndex];
+                    activeHeaderIndex = lastHeaderIndex;
                 }
                 lastHeaderIndex = i;
             }
         });
+
+        if(activeHeader?.itemType?.includes("shared-") && checkShared && activeHeaderIndex + 1 < this.items.items.length)
+        {
+            let totalSharedCount = 0;
+            let totalVisibleSharedCount = 0;
+
+            let activeItemType = this.items.items[activeHeaderIndex + 1].itemType;
+
+            // Update count of shared items
+            this.items.items.forEach((item) =>
+            {
+                if(item.itemType === activeItemType && item.shared)
+                {
+                    totalSharedCount++;
+                    if(item?.content?.layer?.visible)
+                    {
+                        totalVisibleSharedCount++;
+                    }
+                }
+            });
+
+            activeHeader.content.totalCount = totalSharedCount;
+            activeHeader.content.visibleCount = totalVisibleSharedCount;
+        }
 
         return activeHeader;
     }
@@ -259,8 +285,9 @@ export class ExpressionListComponent extends ExpressionListGroupNames implements
         // This if statement is probably unnecessary, but is an extra verification that the header is open 
         if(activeHeader !== null && this.headerSectionsOpen.has(activeHeader.itemType))
         {
-            this.stickyItem = activeHeader;
-            this.stickyItemHeaderName = activeHeaderWithShared.itemType.includes("shared-") ? activeHeaderWithShared.content.label : activeHeader.content.label;
+            let isSharedSectionOpen = activeHeaderWithShared.itemType.includes("shared-");
+            this.stickyItem = isSharedSectionOpen ? activeHeaderWithShared : activeHeader;
+            this.stickyItemHeaderName = isSharedSectionOpen ? activeHeaderWithShared.content.label : activeHeader.content.label;
         }
         else
         {

--- a/client/src/app/UI/atoms/widget-key-display/widget-key-display.component.html
+++ b/client/src/app/UI/atoms/widget-key-display/widget-key-display.component.html
@@ -50,6 +50,9 @@ POSSIBILITY OF SUCH DAMAGE.
             </div>
             <div
                 *ngIf="!item.dashPattern"
+                #tooltip="matTooltip"
+                [matTooltip]="getLabel(item)"
+                [matTooltipDisabled]="getLabel(item).length <= 15"
                 class='main-label'
                 [ngClass]="{'main-label-clickable': item.id.length > 0}"
                 [style]="{'color': item.colour}"
@@ -76,9 +79,9 @@ POSSIBILITY OF SUCH DAMAGE.
                     xmlns="http://www.w3.org/2000/svg">
                     <rect width="12" height="12" rx="0.5" attr.fill="{{item.colour}}" />
                 </svg>
-                {{item.label.replace("mist__roi.", "")}}
+                {{getTruncatedLabel(item)}}
             </div>
-            <div *ngIf="item.dashPattern" class='dash-label'>{{item.label.replace("mist__roi.", "")}}</div>
+            <div *ngIf="item.dashPattern" class='dash-label'>{{getTruncatedLabel(item)}}</div>
         </div>
     </div>
     <ng-content></ng-content>

--- a/client/src/app/UI/atoms/widget-key-display/widget-key-display.component.ts
+++ b/client/src/app/UI/atoms/widget-key-display/widget-key-display.component.ts
@@ -98,4 +98,21 @@ export class WidgetKeyDisplayComponent implements OnInit
             this.keyClick.emit(id);
         }
     }
+
+    getLabel(item: KeyItem): string
+    {
+        return item.label.replace("mist__roi.", "");
+    }
+
+    getTruncatedLabel(item: KeyItem): string
+    {
+        let maxLength = 15;
+        let label = this.getLabel(item);
+        if(label.length > maxLength)
+        {
+            label = label.slice(0, maxLength) + "...";
+        }
+
+        return label;
+    }
 }

--- a/client/src/app/UI/context-image-view-widget/layer-control/layer-control.component.html
+++ b/client/src/app/UI/context-image-view-widget/layer-control/layer-control.component.html
@@ -35,7 +35,9 @@ POSSIBILITY OF SUCH DAMAGE.
             <div class="txt-widget-title">{{title}}</div>
         </div>
         <div fxLayout="row">
-            <filter-box placeholder="Filter Items..." (onFilterChanged)="onFilterExpressions($event)">
+            <filter-box
+                placeholder="Filter Name..."
+                (onFilterChanged)="onFilterExpressions($event)">
             </filter-box>
             <tag-picker
                 type="expression"

--- a/client/src/app/UI/expression-picker/expression-picker.component.html
+++ b/client/src/app/UI/expression-picker/expression-picker.component.html
@@ -34,7 +34,7 @@ POSSIBILITY OF SUCH DAMAGE.
         <div class="txt-widget-title">{{title}}</div>
         <div fxLayout="row" class="filter-container">
             <filter-box
-                placeholder="Filter Expressions..."
+                placeholder="Filter Name..."
                 (onFilterChanged)="onFilterExpressions($event)">
             </filter-box>
             <tag-picker

--- a/client/src/app/UI/parallel-coordinates-plot-widget/parallel-coordinates-plot-widget.component.html
+++ b/client/src/app/UI/parallel-coordinates-plot-widget/parallel-coordinates-plot-widget.component.html
@@ -60,6 +60,7 @@ POSSIBILITY OF SUCH DAMAGE.
 <div fxLayout="column" class="panel outer-panel" fxFill>
     <div fxLayout="row" fxLayoutAlign="space-between center" class="panel-title">
         <widget-switcher [activeSelector]='thisSelector' [widgetPosition]='widgetPosition'></widget-switcher>
+        <push-button (onClick)="onMinerals($event)" title="Choose mineral areas to display" class="minerals-btn">Minerals</push-button>
         <push-button (onClick)="onRegions($event)" title="Choose RGBU regions to display" class="regions-btn">Regions</push-button>
         <icon-button
             class="export-btn"

--- a/client/src/app/UI/parallel-coordinates-plot-widget/parallel-coordinates-plot-widget.component.scss
+++ b/client/src/app/UI/parallel-coordinates-plot-widget/parallel-coordinates-plot-widget.component.scss
@@ -29,8 +29,12 @@
 
 @import 'variables.scss';
 
-.regions-btn {
+.minerals-btn {
     margin-left: auto;
+    margin-right: 4px;
+}
+
+.regions-btn {
     margin-right: 4px;
 }
 

--- a/client/src/app/UI/parallel-coordinates-plot-widget/parallel-coordinates-plot-widget.component.ts
+++ b/client/src/app/UI/parallel-coordinates-plot-widget/parallel-coordinates-plot-widget.component.ts
@@ -43,6 +43,8 @@ import { KeyItem } from "../atoms/widget-key-display/widget-key-display.componen
 import { CSVExportItem, PlotExporterDialogComponent, PlotExporterDialogData, PlotExporterDialogOption } from "../atoms/plot-exporter-dialog/plot-exporter-dialog.component";
 import { DataSetService } from "src/app/services/data-set.service";
 import { MinMax } from "src/app/models/BasicTypes";
+import { RGBUMineralRatios } from "../rgbuplot/rgbu-data";
+import { RGBUPlotModel } from "../rgbuplot/model";
 
 export class PCPLine
 {
@@ -201,6 +203,8 @@ export class ParallelCoordinatesPlotWidgetComponent implements OnInit, OnDestroy
 
     public keyShowing: boolean = false;
     public keyItems: KeyItem[] = [];
+
+    public minerals: string[] = [];
 
     constructor(
         private _elementRef: ElementRef,
@@ -497,6 +501,10 @@ export class ParallelCoordinatesPlotWidgetComponent implements OnInit, OnDestroy
 
         // Make sure we're starting with a clean slate
         this._data = [];
+
+        // Add the visible minerals
+        this._data = this._data.concat(this.visibleMinerals);
+
         let selectedPixels = new Set<number>();
         if(this._selectionService && this._selectionService.getCurrentSelection())
         {
@@ -584,6 +592,45 @@ export class ParallelCoordinatesPlotWidgetComponent implements OnInit, OnDestroy
     get visibleAxes(): PCPAxis[]
     {
         return this.axes.filter((axis) => axis.visible);
+    }
+    
+    get visibleMinerals(): RGBUPoint[]
+    {
+        return this.minerals.map((mineralName) =>
+        {
+            let mineralIndex = RGBUMineralRatios.names.findIndex((mineral) => mineral === mineralName);
+            let rgbuValues = RGBUMineralRatios.ratioValues[mineralIndex];
+
+            return new RGBUPoint(
+                rgbuValues[0] * 255,
+                rgbuValues[1] * 255,
+                rgbuValues[2] * 255,
+                rgbuValues[3] * 255,
+                rgbuValues[0] / rgbuValues[1],
+                rgbuValues[0] / rgbuValues[2],
+                rgbuValues[0] / rgbuValues[3],
+                rgbuValues[1] / rgbuValues[2],
+                rgbuValues[1] / rgbuValues[3],
+                rgbuValues[2] / rgbuValues[3],
+                "234,58,238",
+                mineralName,
+            );
+        });
+    }
+
+    onMinerals(event): void
+    {
+        RGBUPlotModel.selectMinerals(this.dialog, this.minerals, (mineralsShown) => 
+        {
+            if(mineralsShown)
+            {
+                this.minerals = mineralsShown;
+                const reason = "mineral-choice";
+                this.saveState(reason);
+                this._prepareData(reason);
+                this.recalculateLines();
+            }
+        });
     }
 
     toggleLineVisibility(): void

--- a/client/src/app/UI/roipicker/roipicker.component.html
+++ b/client/src/app/UI/roipicker/roipicker.component.html
@@ -39,7 +39,7 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
     <div fxLayout="row" fxLayoutAlign="space-between center" class="card-toolbar card-toolbar-shadow filters-row {{isFiltering ? 'visible-filters' : 'hidden-filters'}}">
         <filter-box 
-            placeholder="Filter ROIs..." 
+            placeholder="Filter Name..."
             (onFilterChanged)="onFilterText($event)"
         >
         </filter-box>

--- a/client/src/app/UI/side-panel/tabs/roi/roi.component.html
+++ b/client/src/app/UI/side-panel/tabs/roi/roi.component.html
@@ -35,7 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
      </div>
      <div *ngIf="showSearch" fxLayout="row" class="gap-separated-horizontal-elements filters-row">
           <filter-box
-               placeholder="Filter ROIs..." 
+               placeholder="Filter Name..."
                (onFilterChanged)="onFilterText($event)"
           >
           </filter-box>

--- a/client/src/app/UI/spectrum-chart-widget/spectrum-region-picker/spectrum-region-picker.component.html
+++ b/client/src/app/UI/spectrum-chart-widget/spectrum-region-picker/spectrum-region-picker.component.html
@@ -43,7 +43,7 @@ POSSIBILITY OF SUCH DAMAGE.
         class="card-toolbar card-toolbar-shadow filters-row {{isFiltering ? 'visible-filters' : 'hidden-filters'}}"
     >
         <filter-box 
-            placeholder="Filter ROIs..." 
+            placeholder="Filter Name..."
             (onFilterChanged)="onFilterText($event)"
         >
         </filter-box>

--- a/client/src/app/models/ExpressionList.ts
+++ b/client/src/app/models/ExpressionList.ts
@@ -747,13 +747,22 @@ export class ExpressionListBuilder extends ExpressionListGroupNames
 
     protected getItems(items: DataExpression[], makeLayer: (source: DataExpression | RGBMix)=>LocationDataLayerProperties): LayerInfo[]
     {
-        let result: LayerInfo[] = [];
+        let layers: LayerInfo[] = [];
         for(let item of items)
         {
             let layer = makeLayer(item);
-            result.push(new LayerInfo(layer, []));
+            layers.push(new LayerInfo(layer, []));
         }
-        return result;
+
+        layers.sort((layerA, layerB) =>
+        {
+            return layerB.layer.source.createUnixTimeSec - layerA.layer.source.createUnixTimeSec;
+        });
+
+        let visibleLayers = layers.filter(layer => layer.layer.visible);
+        let hiddenLayers = layers.filter(layer => !layer.layer.visible);
+        
+        return [...visibleLayers, ...hiddenLayers];
     }
 
     protected getRGBItems(items: RGBMix[], makeLayer: (source: DataExpression | RGBMix)=>LocationDataLayerProperties): RGBLayerInfo[]


### PR DESCRIPTION
- Changes search filter placeholder to "Filter Name" for ROIs and expressions
- Standardizes the axis min/max ranges on the Parallel Coordinates Plot so that all RGBU columns have the same range and all ratio columns have the same range with a 5% buffer added
- Sorts visible expressions to the top of the expression list to match what's done with ROIs
- Fixes bug (adds feature?) with the sticky header when scrolling over a "Shared" section, it shows total item and visible item counts for the entire section instead of just for the shared section. Now it filters down to just show for shared items
- Adds mineral picker to Parallel Coordinates Plot and displays with a pink line
  - Multiple minerals can be displayed, but they all have pink lines, so we might want to revisit this in the future based on use
- Makes widget keys have a max of 15 characters to prevent overflow and adds hover to show the rest