### PR TITLE
Export Single Expression CSV Per ROI

### DIFF
--- a/client/src/app/UI/atoms/buttons/push-button/push-button.component.html
+++ b/client/src/app/UI/atoms/buttons/push-button/push-button.component.html
@@ -29,7 +29,14 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 -->
 
-<div class="clickable" [ngClass]="styleCSS" (click)='onClickInternal($event)'>
+<div
+  class="clickable"
+  [ngClass]="styleCSS"
+  (click)='onClickInternal($event)'
+  #tooltip="matTooltip"
+  [matTooltip]="tooltipTitle"
+  [matTooltipDisabled]="!tooltipTitle || tooltipTitle.length === 0"
+  >
     <ng-content></ng-content>
     <badge
       *ngIf="notificationCount > 0"

--- a/client/src/app/UI/atoms/buttons/push-button/push-button.component.ts
+++ b/client/src/app/UI/atoms/buttons/push-button/push-button.component.ts
@@ -42,6 +42,7 @@ export class PushButtonComponent implements OnInit
     @Input() disabled: boolean = false;
     @Input() notificationCount: number = 0;
     @Input() badgeStyle: BadgeStyle = "notification";
+    @Input() tooltipTitle: string = "";
     @Output() onClick = new EventEmitter();
 
     constructor()

--- a/client/src/app/UI/atoms/export-data-dialog/export-data-dialog.component.html
+++ b/client/src/app/UI/atoms/export-data-dialog/export-data-dialog.component.html
@@ -77,11 +77,11 @@ POSSIBILITY OF SUCH DAMAGE.
 
                 <h3>Options</h3>
                 <multi-switch-button
-                        [options]="['Global', 'Regions of Interest']"
-                        [value]="isGlobal ? 'Global' : 'Regions of Interest'"
-                        [disabled]="false"
-                        (onChange)="onToggleGlobal()">
-                    </multi-switch-button>
+                    [options]="['Global', 'Regions of Interest']"
+                    [value]="isGlobal ? 'Global' : 'Regions of Interest'"
+                    [disabled]="false"
+                    (onChange)="onToggleGlobal()">
+                </multi-switch-button>
                 <ng-container *ngIf="showQuantPicker">
                     <div class="list-subheading">Quantification</div>
                     <mat-select [(ngModel)]="selectedQuantId" class="quantification-select">
@@ -90,8 +90,15 @@ POSSIBILITY OF SUCH DAMAGE.
                 </ng-container>
                 <ng-container *ngIf="!isGlobal">
                     <div fxLayout="row" fxLayoutAlign="space-between center" class="gap-separated-horizontal-elements">
-                        <push-button [title]="roiNameTooltip" (onClick)="onRegions()">Select Regions<img *ngIf="hasSelectedROIs" src="assets/button-icons/yellow-tick.svg"></push-button>
-                        <push-button [title]="expressionNameTooltip" (onClick)="onExpressions()" [disabled]="!hasSelectedROIs">Select Expressions<img *ngIf="hasExpressions" src="assets/button-icons/yellow-tick.svg"></push-button>
+                        <push-button [tooltipTitle]="roiNameTooltip" (onClick)="onRegions()">Select Regions<img *ngIf="hasSelectedROIs" src="assets/button-icons/yellow-tick.svg"></push-button>
+                        <push-button [tooltipTitle]="expressionNameTooltip" (onClick)="onExpressions()" [disabled]="!hasSelectedROIs">Select Expressions<img *ngIf="hasExpressions" src="assets/button-icons/yellow-tick.svg"></push-button>
+                    </div>
+                    <div fxLayout="row" fxLayoutAlign="space-between center" class="gap-separated-horizontal-elements">
+                        <div>One CSV per Region</div>
+                        <two-state-icon-button activeIcon="assets/button-icons/check-on.svg"
+                            inactiveIcon="assets/button-icons/check-off.svg" [active]="singleCSVPerRegion"
+                            (onToggle)="onToggleCSVPerRegion()">
+                        </two-state-icon-button>
                     </div>
                 </ng-container>
 

--- a/client/src/app/UI/atoms/export-data-dialog/export-data-dialog.component.ts
+++ b/client/src/app/UI/atoms/export-data-dialog/export-data-dialog.component.ts
@@ -285,10 +285,22 @@ export class ExportDataDialogComponent implements OnInit
     {
         let count = 0;
 
+        let totalUIROIExpressionCount = 0;
+        if(this.singleCSVPerRegion)
+        {
+            // This is a weird case because all RGBMixes are still exported separately, but non-rgbmixes are exported as a single CSV per ROI
+            let rgbMixExpressionIDs = this._selectedExpressionIds.filter((expressionID) => RGBMixConfigService.isRGBMixID(expressionID));
+            totalUIROIExpressionCount += this._selectedROIs.length * (1 + rgbMixExpressionIDs.length);
+        }
+        else
+        {
+            totalUIROIExpressionCount += this._selectedROIs.length * this._selectedExpressionIds.length;
+        }
+
         let weightedChoices = {
             "raw-spectra": 3,
-            "ui-roi-expressions": this._selectedExpressionIds.length * this._selectedROIs.length,
-            "rois": this._selectedROIs.length,
+            "ui-roi-expressions": totalUIROIExpressionCount,
+            "rois": this._selectedROIs.filter((roi) => !["AllPoints", "SelectedPoints"].includes(roi)).length,
         };
 
         this.visibleChoices.forEach((choice) =>


### PR DESCRIPTION
- Adds export option to combine expression value csvs into a single file per ROI
  - This doesn't apply to RGBMixes and these will be exported into a subfolder
- `SelectedPoints` and `AllPoints` are now selectable and checked by default
- Updates data product count depending on whether `One Region Per CSV` is checked