### PR TITLE
Select All Filtered Button

### DIFF
--- a/client/src/app/UI/atoms/expression-list/layer-settings/layer-settings.component.ts
+++ b/client/src/app/UI/atoms/expression-list/layer-settings/layer-settings.component.ts
@@ -711,7 +711,7 @@ export class LayerSettingsComponent implements OnInit
             showDownload: this.showDownload,
             showShare: this.showShare && !this.sharedBy,
             showTagPicker: this.showTagPicker,
-            showPixlangConvert: this.isPixlangExpression,
+            showPixlangConvert: this.isPixlangExpression && !this.isPredefined,
             showPreviewButton: this.showPreviewButton && !this.isCurrentlyOpen,
             showSplitScreenButton: this.showSplitScreenButton && !this.isCurrentlyOpen && (this.isModule || this.isSplitScreen),
             showSettingsButton: this.showSettingsButton && !this.isCurrentlyOpen,

--- a/client/src/app/UI/expression-picker/expression-picker.component.html
+++ b/client/src/app/UI/expression-picker/expression-picker.component.html
@@ -57,6 +57,16 @@ POSSIBILITY OF SUCH DAMAGE.
                     [value]="author.user_id">{{author.name}}
                 </mat-option>
             </mat-select>
+            <two-state-icon-button
+                *ngIf="!data.singleSelection"
+                class="select-all-toggle"
+                #tooltip="matTooltip"
+                matTooltip="{{isAllFilteredSelected ? 'Deselect' : 'Select'}} all filtered layers"
+                [activeIcon]="activeIcon"
+                [inactiveIcon]="inactiveIcon"
+                [active]="isAllFilteredSelected"
+                (onToggle)="onSelectAllFiltered()">
+            </two-state-icon-button>
         </div>
     </div>
     <expression-list

--- a/client/src/app/UI/expression-picker/expression-picker.component.scss
+++ b/client/src/app/UI/expression-picker/expression-picker.component.scss
@@ -56,3 +56,8 @@
         border: 2px solid rgb(var(--clr-gray-60));
     }
 }
+
+.select-all-toggle {
+    display: flex;
+    align-items: center;
+}

--- a/client/src/app/UI/expression-picker/expression-picker.component.ts
+++ b/client/src/app/UI/expression-picker/expression-picker.component.ts
@@ -81,6 +81,7 @@ export class ExpressionPickerComponent extends ExpressionListGroupNames implemen
     initialScrollToIdx: number = -1;
 
     private _filterText: string = "";
+    private _selectAllFiltered: boolean = false;
 
     private _authors: ObjectCreator[] = [];
     private _filteredAuthors: string[] = [];
@@ -203,12 +204,76 @@ export class ExpressionPickerComponent extends ExpressionListGroupNames implemen
             (source: DataExpression|RGBMix): LocationDataLayerProperties=>
             {
                 let layer = new LocationDataLayerPropertiesWithVisibility(source.id, source.name, source.id, source);
-                layer.visible = (this._activeIDs.has(source.id));
+                if(this._selectAllFiltered)
+                {
+                    if(this.isLayerFiltered(layer, this._filterText, this._filteredAuthors, this.selectedTagIDs))
+                    {
+                        this._activeIDs.add(source.id);
+                        layer.visible = true;
+                    }
+                    else
+                    {
+                        this._activeIDs.delete(source.id);
+                        layer.visible = false;
+                    }
+                }
+                else
+                {
+                    layer.visible = (this._activeIDs.has(source.id));
+                }
                 return layer;
             }
         );
 
         this.authors = this._listBuilder.getAuthors();
+    }
+
+    private isLayerFiltered(layer: LocationDataLayerProperties, filterText: string, filteredAuthors: string[], selectedTagIDs: string[]): boolean
+    {
+        let upperCaseFilter = filterText.toUpperCase();
+        if(upperCaseFilter.length > 0)
+        {
+            let upperName = layer.source.name.toUpperCase();
+            if(upperName.indexOf(upperCaseFilter) === -1)
+            {
+                // Does not contain the filter text, so don't show it
+                return false;
+            }
+        }
+
+        if(filteredAuthors && filteredAuthors.length > 0)
+        {
+            let upperAuthor = layer?.source?.creator?.user_id.toUpperCase();
+            if(!filteredAuthors.map(author => author.toUpperCase()).includes(upperAuthor))
+            {
+                // Was not authored by one of the authors in the filter list
+                return false;
+            }
+        }
+
+        if(selectedTagIDs && selectedTagIDs.length > 0)
+        {
+            let tagIDs = layer?.source?.tags;
+            if(!tagIDs || !selectedTagIDs.every(tag => tagIDs.includes(tag)))
+            {
+                // Was not tagged with one of the tags in the filter list
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    get isAllFilteredSelected(): boolean
+    {
+        return this._selectAllFiltered;
+    }
+    onSelectAllFiltered(): void
+    {
+        this._selectAllFiltered = !this._selectAllFiltered;
+        this._activeIDs.clear();
+
+        this.regenerateItemList();
     }
 
     get authors(): ObjectCreator[]
@@ -288,6 +353,7 @@ export class ExpressionPickerComponent extends ExpressionListGroupNames implemen
         else
         {
             this._activeIDs.delete(event.layerID);
+            this._selectAllFiltered = false;
         }
 
         this.regenerateItemList();


### PR DESCRIPTION
- Adds select all button to select all layers that are filtered in the expression picker
  - This allows for faster exporting of all expressions with a certain tag too
- Fixes bug where predefined expressions have convert to lua button visible