### PR TITLE
Fixing display of error msgs from expressions, we used to show them b…

### DIFF
--- a/client/src/app/services/widget-region-data.service.ts
+++ b/client/src/app/services/widget-region-data.service.ts
@@ -600,7 +600,11 @@ export class WidgetRegionDataService
             if(!exprResult || !exprResult.resultValues)
             {
                 let errorMsg = "Failed to get result for expression: "+query.exprId;
-                
+                if(exprResult && exprResult.errorMsg)
+                {
+                    errorMsg = exprResult.errorMsg;
+                }
+
                 // This expression failed, so anything expecting data from here should just get an error
                 outputResult.queryResults.push(
                     new RegionDataResultItem(exprResult,


### PR DESCRIPTION
…ut now showing a generic failed to get result. This was introduced during the change to only run expression once before ROI segmentation