### PR TITLE
PMC Grid Rebuild and Bug Fixes

### DIFF
--- a/client/src/app/UI/atoms/expression-list/rgbmix-selector/rgbmix-selector.component.ts
+++ b/client/src/app/UI/atoms/expression-list/rgbmix-selector/rgbmix-selector.component.ts
@@ -182,7 +182,7 @@ export class RGBMixSelectorComponent implements OnInit
         //dialogConfig.disableClose = true;
         //dialogConfig.autoFocus = true;
         //dialogConfig.width = '1200px';
-        dialogConfig.data = new ExpressionPickerData(channel+" Expression", selectedId.length > 0 ? [selectedId] : [], true, false, false);
+        dialogConfig.data = new ExpressionPickerData(channel+" Expression", selectedId.length > 0 ? [selectedId] : [], true, false, false, false, false);
 
         const dialogRef = this.dialog.open(ExpressionPickerComponent, dialogConfig);
 

--- a/client/src/app/UI/context-image-view-widget/context-image-view-widget.component.html
+++ b/client/src/app/UI/context-image-view-widget/context-image-view-widget.component.html
@@ -33,6 +33,17 @@ POSSIBILITY OF SUCH DAMAGE.
     <div fxLayout="row" fxLayoutAlign="space-between center" class="panel-title">
         <widget-switcher *ngIf="allowSwitchingTools" [activeSelector]='thisSelector' [widgetPosition]='widgetPosition' [previewMode]="isPreviewMode"></widget-switcher>
         <h1 *ngIf="!allowSwitchingTools" title="Context Image">Context Image</h1>
+        <icon-button
+            *ngIf="isPreviewMode"
+            class="refresh-button"
+            icon="assets/button-icons/refresh-light.svg"
+            (onClick)="onRefreshLayer()"
+            [hasBackground]="false"
+            [state]="0"
+            #tooltip="matTooltip"
+            matTooltip="Refresh the visible layer"
+        >
+        </icon-button>
         <app-context-image-toolbar></app-context-image-toolbar>
     </div>
 

--- a/client/src/app/UI/context-image-view-widget/context-image-view-widget.component.scss
+++ b/client/src/app/UI/context-image-view-widget/context-image-view-widget.component.scss
@@ -58,3 +58,7 @@ h1 {
     text-overflow: ellipsis;
     font-size: 16px;
 }
+
+.refresh-button {
+    margin-right: auto;
+}

--- a/client/src/app/UI/context-image-view-widget/context-image-view-widget.component.ts
+++ b/client/src/app/UI/context-image-view-widget/context-image-view-widget.component.ts
@@ -442,6 +442,13 @@ export class ContextImageViewWidgetComponent implements OnInit, OnDestroy
         return this.previewExpressionIDs && this.previewExpressionIDs.length > 0;
     }
 
+    onRefreshLayer(): void
+    {
+        let validPreviewExpressions = this.previewExpressionIDs.filter(id => this.exprService.getExpression(id));
+        this.mdl.layerManager.setSingleLayerVisible(validPreviewExpressions[0]);
+        this.reDraw();
+    }
+
     private saveState(reason: string): void
     {
         this.mdl.saveState(reason);

--- a/client/src/app/UI/context-image-view-widget/context-image-view-widget.component.ts
+++ b/client/src/app/UI/context-image-view-widget/context-image-view-widget.component.ts
@@ -445,8 +445,11 @@ export class ContextImageViewWidgetComponent implements OnInit, OnDestroy
     onRefreshLayer(): void
     {
         let validPreviewExpressions = this.previewExpressionIDs.filter(id => this.exprService.getExpression(id));
-        this.mdl.layerManager.setSingleLayerVisible(validPreviewExpressions[0]);
-        this.reDraw();
+        if(validPreviewExpressions.length > 0)
+        {
+            this.mdl.layerManager.setSingleLayerVisible(validPreviewExpressions[0]);
+            this.reDraw();
+        }
     }
 
     private saveState(reason: string): void

--- a/client/src/app/UI/context-image-view-widget/layer-manager.ts
+++ b/client/src/app/UI/context-image-view-widget/layer-manager.ts
@@ -465,11 +465,14 @@ export class LayerManager
                 },
                 (err)=>
                 {
-                    // Notify the user & set vis back how it was
-                    alert(err);
-
-                    layer.opacity = prevOpacity;
-                    layer.visible = prevVis;
+                    // Notify the user & set vis back how it was unless it's an unsaved expression
+                    if(!id.startsWith(DataExpressionId.UnsavedExpressionPrefix))
+                    {
+                        alert(err);
+    
+                        layer.opacity = prevOpacity;
+                        layer.visible = prevVis;
+                    }
                 }
             );
         }

--- a/client/src/app/UI/expression-editor/expression-text-editor/expression-text-editor.component.ts
+++ b/client/src/app/UI/expression-editor/expression-text-editor/expression-text-editor.component.ts
@@ -289,6 +289,9 @@ export class ExpressionTextEditorComponent implements OnInit, OnDestroy
             range.startColumn = 1;
         }
 
+        let lastLine = this._editor.getModel().getLineContent(range.endLineNumber);
+        range.endColumn = lastLine.length + 1;
+
         let text = this._editor.getModel().getValueInRange(range);
 
         this.onTextSelect.emit(

--- a/client/src/app/UI/expression-picker/expression-picker.component.ts
+++ b/client/src/app/UI/expression-picker/expression-picker.component.ts
@@ -57,7 +57,8 @@ export class ExpressionPickerData
         public singleSelection: boolean,
         public showRGBMixes: boolean,
         public showAnomalyExpressions: boolean,
-        public isPreviewMode: boolean = false
+        public isPreviewMode: boolean = false,
+        public showModules: boolean = true
     )
     {
     }
@@ -109,7 +110,10 @@ export class ExpressionPickerComponent extends ExpressionListGroupNames implemen
 
     ngOnInit()
     {
-        this._moduleService.refresh();
+        if(this.data.showModules)
+        {
+            this._moduleService.refresh();
+        }
         this._listBuilder = new ExpressionListBuilder(true, ["%"], false, false, this.data.showRGBMixes, this.data.showAnomalyExpressions, this._exprService, this._authService);
 
         this.dialogRef.backdropClick().subscribe(

--- a/client/src/app/UI/pmc-data-grid/pmc-data-grid.component.html
+++ b/client/src/app/UI/pmc-data-grid/pmc-data-grid.component.html
@@ -29,6 +29,21 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 -->
 
+<ng-template #selectionSettingsMenu>
+  <div fxLayout="column" class="gap-separated-vertical-elements">
+    <div fxLayout="column" fxLayoutAlign="start center" >
+        <label>Show PMCs:</label>
+        <two-state-button
+            leftLabel="Non-null"
+            rightLabel="All PMCs"
+            [active]="showAllPMCs"
+            (onToggle)="onToggleValidOnly($event)"
+        >
+        </two-state-button>
+    </div>
+  </div>
+</ng-template>
+
 <div fxLayout="column" class="data-grid">
   <div class="grid-header">
     <h2>{{header}}</h2>
@@ -56,20 +71,27 @@ POSSIBILITY OF SUCH DAMAGE.
         (onClick)="onExport()"
         icon="assets/button-icons/export.svg">
     </icon-button>
+    <widget-settings-menu [settingsDialog]="selectionSettingsMenu">
+      <icon-button
+          class="settings-btn"
+          title="Settings"
+          icon="assets/button-icons/settings.svg">
+      </icon-button>
+    </widget-settings-menu>
   </div>
   <div class="result-container" [style.height]="!isValidTableData ? '100%' : 'auto'">
     <table *ngIf="isValidTableData && isOutputView">
-      <tr *ngFor="let _ of [].constructor(rowCount); let i = index;">
+      <tr *ngFor="let row of data; let i = index;">
         <td
-          *ngFor="let _ of [].constructor(columnCount); let j = index;"
-          class="{{hoveredIndex !== null && hoveredIndex[0] === i && hoveredIndex[1] === j ? 'hover' : ''}} {{selectedPMCs.has(getDataPointPMC(i, j)) ? 'selected' : ''}}"
+          *ngFor="let cell of row; let j = index;"
+          class="{{hoveredIndex !== null && hoveredIndex[0] === i && hoveredIndex[1] === j ? 'hover' : ''}} {{selectedPMCs.has(cell.pmc) ? 'selected' : ''}}"
           (click)="onClickPMC(i, j)"
           (mouseenter)="onMouseEnter(i, j)"
           (mouseleave)="onMouseLeave(i, j)"
           #tooltip="matTooltip"
-          [matTooltip]="getDataTooltip(i, j)"
+          [matTooltip]="cell.tooltip"
         >
-          {{getDataValue(i, j) | number:'1.0-2'}}
+          {{cell.value | number:'1.0-2'}}
         </td>
       </tr>
     </table>

--- a/client/src/app/UI/pmc-data-grid/pmc-data-grid.component.scss
+++ b/client/src/app/UI/pmc-data-grid/pmc-data-grid.component.scss
@@ -61,7 +61,8 @@
             border-color: rgb(var(--clr-gray-70));
         }
 
-        .export-btn {
+        .settings-btn {
+            display: flex;
             margin-right: 8px;
         }
     }
@@ -101,7 +102,7 @@
                 td {
                     height: 14px;
                     min-height: 14px;
-                    
+
                     text-align: center;
                     padding: 6px 4px;
                     color: rgb(var(--clr-gray-30));

--- a/client/src/app/UI/pmc-data-grid/pmc-data-grid.component.scss
+++ b/client/src/app/UI/pmc-data-grid/pmc-data-grid.component.scss
@@ -99,6 +99,9 @@
                 }
 
                 td {
+                    height: 14px;
+                    min-height: 14px;
+                    
                     text-align: center;
                     padding: 6px 4px;
                     color: rgb(var(--clr-gray-30));

--- a/client/src/app/UI/pmc-data-grid/pmc-data-grid.component.ts
+++ b/client/src/app/UI/pmc-data-grid/pmc-data-grid.component.ts
@@ -201,7 +201,7 @@ export class PMCDataGridComponent implements OnInit, OnDestroy
         let values = this._values || [];
         values.forEach((point) =>
         {
-            if(typeof point.value === "number" && !point.isUndefined)
+            if(typeof point.value === "number" && !point.isUndefined && !isNaN(point.value))
             {
                 avgValue += point.value;
                 validPointCount++;

--- a/client/src/app/UI/pmc-data-grid/pmc-data-grid.component.ts
+++ b/client/src/app/UI/pmc-data-grid/pmc-data-grid.component.ts
@@ -27,7 +27,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, SimpleChanges } from "@angular/core";
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from "@angular/core";
 import { Subscription } from "rxjs";
 import { PMCDataValue, PMCDataValues } from "src/app/expression-language/data-values";
 import { ContextImageService } from "src/app/services/context-image.service";
@@ -39,6 +39,11 @@ import { BeamSelection } from "src/app/models/BeamSelection";
 import { DataQueryResult } from "src/app/expression-language/data-values";
 import { DataExpression } from "src/app/models/Expression";
 
+export interface DataCell {
+    pmc: number;
+    value: string|number;
+    tooltip: string;
+}
 
 @Component({
     selector: "pmc-data-grid",
@@ -51,25 +56,37 @@ export class PMCDataGridComponent implements OnInit, OnDestroy
     private _subs = new Subscription();
 
     @Input() header: string = "Data Grid";
-    @Input() evaluatedExpression: DataQueryResult = null;
+    // @Input() evaluatedExpression: DataQueryResult = null;
     @Input() expression: DataExpression = null;
     @Input() columnCount: number = 0;
     @Input() stdout: string = "";
     @Input() stderr: string = "";
 
     @Output() onToggleSolo = new EventEmitter();
-
     private _isSolo: boolean = false;
 
-    private _isOutputView: boolean = true;
+    private _values: PMCDataValue[] = null;
+    private _evaluatedExpression: DataQueryResult = null;
+    
+    public rowCount: number = 0;
+    public data: DataCell[][] = [];
+    public printableResultValue: string = "";
+    public isValidData: boolean = false;
+    public isValidTableData: boolean = false;
+    
+    public minDataValue: number = 0;
+    public maxDataValue: number = 0;
+    public avgDataValue: number = 0;
 
-    private _pmcToValueIdx = new Map<number, number>();
+    private _isOutputView: boolean = true;
+    private _pmcToValueIdx: Map<number, {row: number; col: number;}> = new Map();
 
     selectedPMCs: Set<number> = new Set();
     currentSelection: SelectionHistoryItem = null;
-
+    
     public copyIcon: string = "content_copy";
 
+    public showAllPMCs: boolean = true;
     constructor(
         private _selectionService: SelectionService,
         private _datasetService: DataSetService,
@@ -87,51 +104,47 @@ export class PMCDataGridComponent implements OnInit, OnDestroy
         });
     }
 
-    ngOnChanges(changes: SimpleChanges): void
-    {
-        // Rebuild our PMC->value index lookup
-        if(changes["evaluatedExpression"])
-        {
-            this._pmcToValueIdx.clear();
-            if(this.evaluatedExpression?.resultValues?.values)
-            {
-                for(let c = 0; c < this.evaluatedExpression.resultValues.values.length; c++)
-                {
-                    this._pmcToValueIdx.set(this.evaluatedExpression.resultValues.values[c].pmc, c);
-                }
-            }
-        }
-    }
-
     ngOnDestroy()
     {
         this._subs.unsubscribe();
     }
 
-    get isOutputView(): boolean
+    get evaluatedExpression(): DataQueryResult
     {
-        return !this.stderr && this._isOutputView;
+        return this._evaluatedExpression;
     }
 
-    set isOutputView(value: boolean)
+    @Input() set evaluatedExpression(value: DataQueryResult)
     {
-        this._isOutputView = value;
+        this._evaluatedExpression = value;
+
+        this.preComputeData();
     }
 
-    get toggleTooltip(): string
+    preComputeData()
     {
-        return this.stderr ? "Fix the errors below to enable output view" : "Switch between code return output and log view";
+        this._values = this._evaluatedExpression?.resultValues?.values || [];
+        if(!this.showAllPMCs)
+        {
+            this._values = this._values.filter((value) => !isNaN(Number(value?.value)));
+        }
+        this.rowCount = this.calculateRowCount();
+        this.printableResultValue = this.calculatePrintableResultValue();
+        this.isValidData = this.calculateIsValidData();
+        this.isValidTableData = this.calculateIsValidTableData();
+        this.calculateStats();
+        this.calculateData();
     }
 
-    get rowCount(): number
+    calculateRowCount(): number
     {
-        let count = this.evaluatedExpression?.resultValues?.values.length; 
+        let count = this._values.length; 
         return count && this.columnCount > 0 ? Math.floor(count / this.columnCount) : 0;
     }
 
-    get printableResultValue(): string
+    calculatePrintableResultValue()
     {
-        let values = this.evaluatedExpression?.resultValues;
+        let values = this._evaluatedExpression?.resultValues;
         if(this.isValidTableData)
         {
             return values.values.map((point) => point.value).join(", ");
@@ -165,34 +178,27 @@ export class PMCDataGridComponent implements OnInit, OnDestroy
         }
     }
 
-    get isValidData(): boolean
+    calculateIsValidData(): boolean
     {
-        let values = this.evaluatedExpression?.resultValues;
+        let values = this._evaluatedExpression?.resultValues;
         return typeof values !== "undefined" && values !== null && (!Array.isArray(values?.values) || values.values.length > 0);
     }
 
-    get isValidTableData(): boolean
+    calculateIsValidTableData(): boolean
     {
         let values = this.evaluatedExpression?.resultValues;
-        return values instanceof PMCDataValues && values?.values.length > 0;
+        return values instanceof PMCDataValues && values?.values?.length > 0;
     }
 
-    get minDataValue(): number
+    calculateStats()
     {
-        return this.evaluatedExpression?.resultValues?.valueRange?.min || 0;
-    }
+        this.minDataValue = this._evaluatedExpression?.resultValues?.valueRange?.min || 0;
+        this.maxDataValue = this._evaluatedExpression?.resultValues?.valueRange?.max || 0;
 
-    get maxDataValue(): number
-    {
-        return this.evaluatedExpression?.resultValues?.valueRange?.max || 0;
-    }
-
-    get avgDataValue(): number
-    {
         let avgValue = null;
         let validPointCount = 0;
 
-        let values = this.evaluatedExpression?.resultValues?.values || [];
+        let values = this._values || [];
         values.forEach((point) =>
         {
             if(typeof point.value === "number" && !point.isUndefined)
@@ -202,50 +208,34 @@ export class PMCDataGridComponent implements OnInit, OnDestroy
             }
         });
 
-        return avgValue !== null && validPointCount > 0 ? avgValue / validPointCount : 0;
+        this.avgDataValue = avgValue !== null && validPointCount > 0 ? avgValue / validPointCount : 0;
     }
 
-    get hoveredIndex(): number[]
-    {
-        if(this.isValidTableData && this._selectionService.hoverPMC !== -1 && this.evaluatedExpression?.resultValues)
-        {
-            // Find the idx of hovered PMC value
-            let valIdx = this._pmcToValueIdx.get(this._selectionService.hoverPMC);
-            if(valIdx !== undefined)
-            {
-                let row = Math.floor(valIdx / this.columnCount);
-                let col = valIdx % this.columnCount;
-                return [row, col];
-            }
-        }
-        return null;
-    }
-
-    private getDataPoint(row: number, col: number): PMCDataValue
+    private _getDataPoint(row: number, col: number): PMCDataValue
     {
         let index = row * this.columnCount + col;
-        if(index >= this.evaluatedExpression.resultValues.values.length)
+        if(index >= this._values.length)
         {
             return null;
         }
         
-        return this.evaluatedExpression.resultValues.values[index];
+        return this._values[index];
     }
 
-    getDataPointPMC(row: number, col: number): number
+    private _getDataPointPMC(row: number, col: number): number
     {
-        return this.getDataPoint(row, col)?.pmc || null;
+        return this._getDataPoint(row, col)?.pmc || null;
     }
     
-    getDataValue(row: number, col: number): number|string
+    private _getDataValue(row: number, col: number): number|string
     {
-        let value = this.getDataPoint(row, col)?.value;
+        let value = this._getDataPoint(row, col)?.value;
         return [null, undefined].includes(value) ? "" : value;
     }
 
-    getDataTooltip(row: number, col: number): string
+    private _getDataTooltip(row: number, col: number): string
     {
-        let point = this.getDataPoint(row, col);
+        let point = this._getDataPoint(row, col);
         if(point === null)
         {
             return "Undefined";
@@ -255,6 +245,70 @@ export class PMCDataGridComponent implements OnInit, OnDestroy
             let roundedValue = typeof point.value === "number" ? Math.round(point.value * 1000) / 1000 : point.value;
             return `PMC: ${point.pmc}\nValue: ${point.isUndefined ? "Undefined" : roundedValue}`;
         }
+    }
+
+    calculateData()
+    {
+        let data: DataCell[][] = [];
+        for(let rowIndex = 0; rowIndex < this.rowCount; rowIndex++)
+        {
+            let row: DataCell[] = [];
+            for(let colIndex = 0; colIndex < this.columnCount; colIndex++)
+            {
+                let pmc = this._getDataPointPMC(rowIndex, colIndex);
+                let value = this._getDataValue(rowIndex, colIndex);
+
+                if(!this.showAllPMCs && isNaN(Number(value)))
+                {
+                    continue;
+                }
+
+                row.push({
+                    pmc,
+                    value,
+                    tooltip: this._getDataTooltip(rowIndex, colIndex)
+                });
+
+                this._pmcToValueIdx.set(pmc, {row: rowIndex, col: colIndex});
+            }
+            data.push(row);
+        }
+
+        this.data = data;
+    }
+
+    get isOutputView(): boolean
+    {
+        return !this.stderr && this._isOutputView;
+    }
+
+    set isOutputView(value: boolean)
+    {
+        this._isOutputView = value;
+    }
+
+    get toggleTooltip(): string
+    {
+        return this.stderr ? "Fix the errors below to enable output view" : "Switch between code return output and log view";
+    }
+
+    get hoveredIndex(): number[]
+    {
+        if(this.isValidTableData && this._selectionService.hoverPMC !== -1 && this._pmcToValueIdx.size > 0)
+        {
+            let point = this._pmcToValueIdx.get(this._selectionService.hoverPMC);
+            if(point !== undefined)
+            {
+                return [point.row, point.col];
+            }
+        }
+        return null;
+    }
+
+    onToggleValidOnly(showAllPMCs: boolean)
+    {
+        this.showAllPMCs = showAllPMCs;
+        this.preComputeData();
     }
 
     onSolo()
@@ -270,8 +324,8 @@ export class PMCDataGridComponent implements OnInit, OnDestroy
 
     onMouseEnter(row: number, col: number)
     {
-        let point = this.getDataPoint(row, col);
-        if(point !== null)
+        let point = this.data[row][col];
+        if(point !== null && point !== undefined)
         {
             this._selectionService.setHoverPMC(point.pmc);
         }
@@ -279,8 +333,8 @@ export class PMCDataGridComponent implements OnInit, OnDestroy
 
     onMouseLeave(row: number, col: number)
     {
-        let point = this.getDataPoint(row, col);
-        if(point !== null && this._selectionService.hoverPMC === point.pmc)
+        let point = this.data[row][col];
+        if(point !== null && point !== undefined && this._selectionService.hoverPMC === point.pmc)
         {
             this._selectionService.setHoverPMC(-1);
         }
@@ -289,7 +343,7 @@ export class PMCDataGridComponent implements OnInit, OnDestroy
     onClickPMC(row: number, col: number)
     {
         let dataset = this._datasetService.datasetLoaded;
-        let pmc = this.getDataPointPMC(row, col);
+        let pmc = this.data[row][col]?.pmc;
         let selectedLocIndex = dataset.pmcToLocationIndex.get(pmc);
         let { beamSelection, pixelSelection } = this.currentSelection;
         
@@ -323,22 +377,22 @@ export class PMCDataGridComponent implements OnInit, OnDestroy
 
     onCopyStdout()
     {
-        this._copyText(this.evaluatedExpression?.stdout.trim());
+        this._copyText(this._evaluatedExpression?.stdout.trim());
     }
 
     onCopyStderr()
     {
-        this._copyText(this.evaluatedExpression?.stderr.trim());
+        this._copyText(this._evaluatedExpression?.stderr.trim());
     }
 
     onExport()
     {
-        if(!this.evaluatedExpression || !this.expression)
+        if(!this._evaluatedExpression || !this.expression)
         {
             return;
         }
 
-        let validExpressionValues = this.evaluatedExpression?.resultValues?.values.length > 0;
+        let validExpressionValues = this._values.length > 0;
         let exportOptions = [
             new PlotExporterDialogOption("Expression Values .csv", validExpressionValues, false, { type: "checkbox", disabled: !validExpressionValues }),
             new PlotExporterDialogOption("Expression Output .txt", true),

--- a/client/src/app/routes/dataset/code-editor/code-editor.component.html
+++ b/client/src/app/routes/dataset/code-editor/code-editor.component.html
@@ -126,7 +126,6 @@ POSSIBILITY OF SUCH DAMAGE.
                 <push-button
                     class="run-btn"
                     buttonStyle="yellow"
-                    [disabled]="!isRunable"
                     (onClick)="runExpression()"
                     #tooltip="matTooltip"
                     [matTooltip]="runCodeTooltip"

--- a/client/src/app/routes/dataset/code-editor/code-editor.component.html
+++ b/client/src/app/routes/dataset/code-editor/code-editor.component.html
@@ -164,7 +164,7 @@ POSSIBILITY OF SUCH DAMAGE.
             </div>
         </div>
     </div>
-    <div fxLayout="row" class="editor-body {{isSidebarOpen ? 'sidebar-open' : ''}}">
+    <div fxLayout="row" class="editor-body {{isSidebarOpen ? 'sidebar-open' : 'sidebar-closed'}}">
         <div class="sidebar">
             <div *ngIf="isSidebarOpen" fxLayout="row" class="filter-container">
                 <filter-box

--- a/client/src/app/routes/dataset/code-editor/code-editor.component.html
+++ b/client/src/app/routes/dataset/code-editor/code-editor.component.html
@@ -437,10 +437,10 @@ POSSIBILITY OF SUCH DAMAGE.
                     (onClick)="onCopyToNewExpression()"
                     #tooltip="matTooltip"
                     matTooltip="Copy the open expression to a new expression."
-                >Copy Expression
+                >Copy To New
                 </push-button>
                 <push-button
-                    *ngIf="!topEditor.isModule"
+                    *ngIf="!topEditor.isModule && topEditor.editable"
                     class="save-btn"
                     [buttonStyle]="topEditor.invalidExpression ? 'orange' : 'yellow'"
                     [disabled]="!topEditor.editable || topEditor.isExpressionSaved || topEditor.invalidExpression"

--- a/client/src/app/routes/dataset/code-editor/code-editor.component.scss
+++ b/client/src/app/routes/dataset/code-editor/code-editor.component.scss
@@ -301,6 +301,12 @@
     flex-direction: column;
 }
 
+.sidebar-closed {
+    .sidebar {
+        display: none !important;
+    }
+}
+
 .sidebar-open {
     .sidebar-header {
         width: 300px;
@@ -311,7 +317,7 @@
     }
 
     .sidebar {
-        min-width: 300px;
+        width: 300px;
     }
 
     .preview-container, .viz-panels, pmc-data-grid {

--- a/client/src/app/routes/dataset/code-editor/code-editor.component.ts
+++ b/client/src/app/routes/dataset/code-editor/code-editor.component.ts
@@ -497,7 +497,7 @@ export class CodeEditorComponent extends ExpressionListGroupNames implements OnI
 
                     this._runExpressionTimer = setTimeout(() =>
                     {
-                        this.runExpression(true, true);
+                        this.runExpression();
                         this._runExpressionTimer = null;
                     }, 5000);
                 },
@@ -776,7 +776,7 @@ export class CodeEditorComponent extends ExpressionListGroupNames implements OnI
 
             this._runExpressionTimer = setTimeout(() =>
             {
-                this.runExpression(true, true);
+                this.runExpression();
                 this._runExpressionTimer = null;
             }, 5000);
 
@@ -1320,13 +1320,8 @@ export class CodeEditorComponent extends ExpressionListGroupNames implements OnI
         return DataExpressionId.UnsavedExpressionPrefix+this._expressionID;
     }
 
-    runExpression(runTop: boolean = true, forceRun: boolean = false): void
+    runExpression(runTop: boolean = true): void
     {
-        if(!this.isRunable && !forceRun)
-        {
-            return;
-        }
-
         this.lastRunEditor = runTop ? "top" : "bottom";
         let editor = runTop ? this.topEditor : this.bottomEditor;
         if(this._expressionID && editor.expression)
@@ -1524,13 +1519,6 @@ export class CodeEditorComponent extends ExpressionListGroupNames implements OnI
     get isNewID(): boolean
     {
         return this._newExpression;
-    }
-
-    get isRunable(): boolean
-    {
-        let otherEditorActive = this.isTopEditorActive && this.lastRunEditor !== "top" || !this.isTopEditorActive && this.lastRunEditor !== "bottom";
-        let isCodeChanged = this.isTopEditorActive ? this.topEditor.isCodeChanged : this.bottomEditor.isCodeChanged;
-        return otherEditorActive || isCodeChanged || !this.isEvaluatedDataValid;
     }
 
     get textHighlighted(): string

--- a/client/src/app/routes/dataset/code-editor/code-editor.component.ts
+++ b/client/src/app/routes/dataset/code-editor/code-editor.component.ts
@@ -1546,7 +1546,9 @@ export class CodeEditorComponent extends ExpressionListGroupNames implements OnI
     get moduleSidebarTooltip(): string
     {
         let tooltip = this.isSidebarOpen ? "Close Modules Sidebar" : "Open Modules Sidebar";
-        return tooltip + (this.isWindows ? " (Ctrl+B)" : " (Cmd+B)");
+        let cmdOrCtrl = this.isWindows ? "Ctrl" : "Cmd";
+        let altKeyName = this.isFirefox ? this.isWindows ? "+Alt" : "+Option" : "";
+        return `${tooltip} (${cmdOrCtrl}${altKeyName}+B)`;
     }
 
     get saveModuleTooltip(): string
@@ -1597,10 +1599,14 @@ export class CodeEditorComponent extends ExpressionListGroupNames implements OnI
         return "Open Release Module Dialog";
     }
 
-
     get isWindows(): boolean
     {
         return navigator.userAgent.search("Windows") !== -1;
+    }
+
+    get isFirefox(): boolean
+    {
+        return !!navigator.userAgent.match(/firefox|fxios/i);
     }
 
     get isEmptySelection(): boolean
@@ -1919,51 +1925,59 @@ export class CodeEditorComponent extends ExpressionListGroupNames implements OnI
     @HostListener("window:keydown", ["$event"])
     onKeydown(event: KeyboardEvent): void
     {
+        let cmdOrCtrl = this.isWindows ? "Control" : "Meta";
+
         this._keyPresses[event.key] = true;
-        if((this._keyPresses["Meta"] && this._keyPresses["Enter"]) || (this._keyPresses["Control"] && this._keyPresses["Enter"]))
+        if((this._keyPresses[cmdOrCtrl] && this._keyPresses["Enter"]))
         {
             this.runExpression();
-            if(event.key === "Meta" || event.key === "Control")
+            if(event.key === cmdOrCtrl)
             {
-                this._keyPresses["Meta"] = false;
-                this._keyPresses["Control"] = false;
+                this._keyPresses[cmdOrCtrl] = false;
                 this._keyPresses["Enter"] = false;
             }
             this._keyPresses[event.key] = false;
         }
-        else if((this._keyPresses["Meta"] && this._keyPresses["s"]) || (this._keyPresses["Control"] && this._keyPresses["s"]))
+        else if((this._keyPresses[cmdOrCtrl] && this._keyPresses["s"]))
         {
             this.onSave();
             this._keyPresses[event.key] = false;
-            if(event.key === "Meta" || event.key === "Control")
+            if(event.key === cmdOrCtrl)
             {
-                this._keyPresses["Meta"] = false;
-                this._keyPresses["Control"] = false;
+                this._keyPresses[cmdOrCtrl] = false;
                 this._keyPresses["s"] = false;
             }
             event.stopPropagation();
             event.stopImmediatePropagation();
             event.preventDefault();
         }
-        else if((this._keyPresses["Meta"] && this._keyPresses["b"]) || (this._keyPresses["Control"] && this._keyPresses["b"]))
+        else if((this._keyPresses[cmdOrCtrl] && this._keyPresses["b"]) && !this.isFirefox)
         {
             this.onToggleSidebar();
             this._keyPresses[event.key] = false;
-            if(event.key === "Meta" || event.key === "Control")
+            if(event.key === cmdOrCtrl)
             {
-                this._keyPresses["Meta"] = false;
-                this._keyPresses["Control"] = false;
+                this._keyPresses[cmdOrCtrl] = false;
                 this._keyPresses["b"] = false;
             }
         }
-        else if((this._keyPresses["Meta"] && this._keyPresses["\\"]) || (this._keyPresses["Control"] && this._keyPresses["\\"]))
+        else if((this._keyPresses[cmdOrCtrl] && this._keyPresses["∫"]) && this.isFirefox)
+        {
+            this.onToggleSidebar();
+            this._keyPresses[event.key] = false;
+            if(event.key === cmdOrCtrl)
+            {
+                this._keyPresses[cmdOrCtrl] = false;
+                this._keyPresses["∫"] = false;
+            }
+        }
+        else if((this._keyPresses[cmdOrCtrl] && this._keyPresses["\\"]))
         {
             this.onToggleSplitScreen();
             this._keyPresses[event.key] = false;
-            if(event.key === "Meta" || event.key === "Control")
+            if(event.key === cmdOrCtrl)
             {
-                this._keyPresses["Meta"] = false;
-                this._keyPresses["Control"] = false;
+                this._keyPresses[cmdOrCtrl] = false;
                 this._keyPresses["\\"] = false;
             }
         }

--- a/client/src/app/routes/dataset/code-editor/code-editor.component.ts
+++ b/client/src/app/routes/dataset/code-editor/code-editor.component.ts
@@ -1459,14 +1459,14 @@ export class CodeEditorComponent extends ExpressionListGroupNames implements OnI
         );
 
         let lineRange = "";
-        let isMultiLine = this.startLineHighlighted !== this.endLineHighlighted || this.isEmptySelection;
+        let isMultiLine = this.startLineHighlighted !== this.endLineHighlighted || (this.isEmptySelection && this.endLineHighlighted > 1);
         if(this.isEmptySelection)
         {
-            lineRange = `0 - ${this.endLineHighlighted}`;
+            lineRange = this.endLineHighlighted === 1 ? "1" : `1 - ${this.endLineHighlighted}`;
         }
         else
         {
-            lineRange = !isMultiLine ? `${this.startLineHighlighted}` : `${this.startLineHighlighted} - ${this.endLineHighlighted}`;
+            lineRange = !isMultiLine ? `${this.startLineHighlighted}` : `${this.startLineHighlighted + 1} - ${this.endLineHighlighted}`;
         }
         
         this.displayExpressionTitle = `Unsaved ${this.topEditor.expression.name} (Line${isMultiLine ? "s": ""} ${lineRange})`;

--- a/client/src/app/routes/dataset/code-editor/code-editor.component.ts
+++ b/client/src/app/routes/dataset/code-editor/code-editor.component.ts
@@ -80,7 +80,7 @@ export class CodeEditorComponent extends ExpressionListGroupNames implements OnI
     private _expressionID: string = DataExpressionId.UnsavedExpressionPrefix+"-new-expression";
     private _runExpressionTimer = null;
 
-    public isSidebarOpen = false;
+    private _isSidebarOpen = false;
     // What we display in the virtual-scroll capable list
     headerSectionsOpen: Set<string> = new Set<string>([this.currentlyOpenHeaderName]);
     items: ExpressionListItems = null;
@@ -169,8 +169,8 @@ export class CodeEditorComponent extends ExpressionListGroupNames implements OnI
     )
     {
         super();
+        this.fetchLocalStorageMetadata();
     }
-
 
     ngOnInit()
     {
@@ -233,6 +233,29 @@ export class CodeEditorComponent extends ExpressionListGroupNames implements OnI
             }
         });
     }
+
+    get isSidebarOpen(): boolean
+    {
+        return this._isSidebarOpen;
+    }
+
+    set isSidebarOpen(value: boolean)
+    {
+        this._isSidebarOpen = value;
+        this.storeMetadata();
+    }
+
+    storeMetadata(): void
+    {
+        localStorage.setItem("isSidebarOpen", this.isSidebarOpen.toString());
+    }
+
+    fetchLocalStorageMetadata(): void
+    {
+        let isSidebarOpen = localStorage?.getItem("isSidebarOpen") || false;
+        this.isSidebarOpen = isSidebarOpen === "true";
+    }
+
 
     syncCurrentlyOpenSection(): void
     {

--- a/client/src/app/services/monaco-editor.service.ts
+++ b/client/src/app/services/monaco-editor.service.ts
@@ -193,6 +193,7 @@ export class MonacoEditorService
                 { token: "number", foreground: "#FF5370" },
                 { token: "constant", foreground: "#91bfdb" },
                 { token: "delimiter", foreground: "#89ddff" },
+                { token: "special-char", foreground: "#D16969" },
             ],
             colors: {
                 "entity.name.function": "#ffff8d",

--- a/client/src/app/services/view-state.service.ts
+++ b/client/src/app/services/view-state.service.ts
@@ -1688,7 +1688,7 @@ export class ViewStateService
 
     convertAnnotationsFromWireFrame(annotations: fullScreenAnnotationItemWireFrame[]): FullScreenAnnotationItem[]
     {
-        return annotations.map(annotationWireFrame =>
+        return (annotations || []).map(annotationWireFrame =>
             new FullScreenAnnotationItem(
                 annotationWireFrame.type as AnnotationToolOption,
                 annotationWireFrame.points.map(point => new AnnotationPoint(point.x, point.y, point.screenWidth, point.screenHeight)),
@@ -1703,7 +1703,7 @@ export class ViewStateService
 
     convertAnnotationsToWireFrame(annotations: FullScreenAnnotationItem[]): fullScreenAnnotationItemWireFrame[]
     {
-        return annotations.map(annotation =>
+        return (annotations || []).map(annotation =>
         {
             return {
                 type: annotation.type,

--- a/client/src/app/services/widget-region-data.service.ts
+++ b/client/src/app/services/widget-region-data.service.ts
@@ -523,7 +523,7 @@ export class WidgetRegionDataService
                                     errorMsg.indexOf("The currently loaded quantification does not contain column") < 0
                                 )
                                 {
-                                    SentryHelper.logMsg(true, errorMsg);
+                                    // SentryHelper.logMsg(true, errorMsg);
                                 }
 
                                 return of(new DataQueryResult(null, false, [], null, "", "", null, errorMsg));

--- a/client/src/app/services/widget-region-data.service.ts
+++ b/client/src/app/services/widget-region-data.service.ts
@@ -523,7 +523,7 @@ export class WidgetRegionDataService
                                     errorMsg.indexOf("The currently loaded quantification does not contain column") < 0
                                 )
                                 {
-                                    // SentryHelper.logMsg(true, errorMsg);
+                                    SentryHelper.logMsg(true, errorMsg);
                                 }
 
                                 return of(new DataQueryResult(null, false, [], null, "", "", null, errorMsg));


### PR DESCRIPTION
- Adds refresh button to trigger setLayerVisibility to true for unsaved expression
- Replaces "Save Expression" with “Copy To New”
- Rebuilds PMC grid to precompute data on new expression
  - Adds “Show nulls” to PMC grid
- Changes firefox sidebar shortcut to `cmd + Alt + B`
- Store sidebar open boolean to local storage
- Always allows re-running of expressions
- Fixes bug with RGB mixes not working due to modules reloading panel on init
- Fixes bug with "run until line" where it only runs to the character of the line you're on instead of the end