### PR TITLE
Shortcut Refactoring and Bug Fixes

### DIFF
--- a/client/src/app/UI/pmc-data-grid/pmc-data-grid.component.html
+++ b/client/src/app/UI/pmc-data-grid/pmc-data-grid.component.html
@@ -109,12 +109,12 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
 
     <div *ngIf="!isOutputView && !stderr" class="log-text">{{stdout ? stdout.trim() : "No log output"}}
-      <div class="copy-btn" (click)="onCopyStdout()">
+      <div *ngIf="stdout" class="copy-btn" (click)="onCopyStdout()">
         <mat-icon>{{copyIcon}}</mat-icon>Copy
       </div>
     </div>
     <div *ngIf="!isOutputView && stderr" class="error-text">{{stderr ? stderr.trim() : "No log output"}}
-      <div class="copy-btn" (click)="onCopyStderr()">
+      <div *ngIf="stderr" class="copy-btn" (click)="onCopyStderr()">
         <mat-icon>{{copyIcon}}</mat-icon>Copy
       </div>
     </div>

--- a/client/src/app/UI/pmc-data-grid/pmc-data-grid.component.ts
+++ b/client/src/app/UI/pmc-data-grid/pmc-data-grid.component.ts
@@ -147,7 +147,7 @@ export class PMCDataGridComponent implements OnInit, OnDestroy
         let values = this._evaluatedExpression?.resultValues;
         if(this.isValidTableData)
         {
-            return values.values.map((point) => point.value).join(", ");
+            return values?.values?.map((point) => point.value).join(", ") || "";
         }
         
         if(Array.isArray(values))
@@ -377,12 +377,12 @@ export class PMCDataGridComponent implements OnInit, OnDestroy
 
     onCopyStdout()
     {
-        this._copyText(this._evaluatedExpression?.stdout.trim());
+        this._copyText(this.stdout?.trim());
     }
 
     onCopyStderr()
     {
-        this._copyText(this._evaluatedExpression?.stderr.trim());
+        this._copyText(this.stderr?.trim());
     }
 
     onExport()

--- a/client/src/app/UI/side-panel/side-panel.component.html
+++ b/client/src/app/UI/side-panel/side-panel.component.html
@@ -32,7 +32,13 @@ POSSIBILITY OF SUCH DAMAGE.
 <div fxLayout="column" class="side-panel" fxFill>
     <ng-container *ngIf="!isOpen">
         <div fxLayout="row" fxLayoutAlign="end" class="panel-row gap-separated-horizontal-elements">
-            <img class="clickable" (click)="onToggleSidePanel()" src="assets/button-icons/side-panel-open.svg">
+            <img
+                class="clickable"
+                (click)="onToggleSidePanel()"
+                src="assets/button-icons/side-panel-open.svg"
+                #tooltip="matTooltip"
+                [matTooltip]="toggleSidePanelTooltip"
+            >
         </div>
         <div *ngIf="presentationActive" fxLayout="column" class="play-bar gap-separated-vertical-elements">
             <span>{{presentationSlideIdx}} of {{presentationSlideCount}}</span>
@@ -93,44 +99,29 @@ POSSIBILITY OF SUCH DAMAGE.
                     inactiveIcon="assets/button-icons/filter-white.svg"
                     [active]="showSearch"
                     (onToggle)="onToggleSearch()"
-                    title="Toggle showing search"></two-state-icon-push-button>
+                    #tooltip="matTooltip"
+                    matTooltip="{{showSearch ? 'Hide' : 'Show'}} search options"
+                ></two-state-icon-push-button>
                 <two-state-icon-push-button
                     *ngIf="showSharedButton"
                     activeIcon="assets/button-icons/share-yellow.svg"
                     inactiveIcon="assets/button-icons/share.svg"
                     [active]="showShared"
                     (onToggle)="onToggleShared()"
-                    title="Toggle showing shared items only"></two-state-icon-push-button>
-<!--                <two-state-icon-push-button
-                    *ngIf="showFilterButton"
-                    activeIcon="assets/button-icons/filter-yellow.svg"
-                    inactiveIcon="assets/button-icons/filter-white.svg"
-                    [active]="showFiltered"
-                    (onToggle)="onToggleFiltered()"
-                    title="Toggle showing filtering options">
-                </two-state-icon-push-button> -->
-                <img class="clickable" (click)="onToggleSidePanel()" src="assets/button-icons/side-panel-close.svg">
+                    #tooltip="matTooltip"
+                    matTooltip="{{showShared ? 'Show Non-Shared Items Only' : 'Show Shared Items Only'}}"
+                ></two-state-icon-push-button>
+                <img
+                    class="clickable"
+                    (click)="onToggleSidePanel()"
+                    src="assets/button-icons/side-panel-close.svg"
+                    #tooltip="matTooltip"
+                    [matTooltip]="toggleSidePanelTooltip"
+                >
             </div>
         </div>
         <div class="tab-host-area" fxFlex="100%">
             <div #tabHostTop></div>
         </div>
-<!-- Removed bottom panel due to many edge cases where long scrolling list areas broke the layout if we had 2 panels like that showing
-
-        <div fxLayout="row" fxLayoutAlign="space-between center" class="panel-row gap-separated-horizontal-elements">
-            <mat-select *ngIf="isOpen" [(ngModel)]="activeTabBottom">
-                <mat-option *ngFor="let tab of tabsWithNone" [value]="tab">
-                    <div fxLayout="row" fxLayoutAlign="space-between center">
-                        <span>{{tab}}</span><img [src]="tabIcon(tab)">
-                    </div>
-                </mat-option>
-            </mat-select>
-            <img *ngIf="!bottomIsNoneTab" class="clickable" (click)="onSizePanel()" src="assets/icons/resizer.svg">
-        </div>
-        <div class="item tab-host-area">
-            <div #tabHostBottom></div>
-        </div>
--->
-
     </ng-container>
 </div>

--- a/client/src/app/UI/side-panel/side-panel.component.ts
+++ b/client/src/app/UI/side-panel/side-panel.component.ts
@@ -418,6 +418,24 @@ export class SidePanelComponent implements OnInit
         }
     }
 
+    get isWindows(): boolean
+    {
+        return navigator.userAgent.search("Windows") !== -1;
+    }
+
+    get isFirefox(): boolean
+    {
+        return !!navigator.userAgent.match(/firefox|fxios/i);
+    }
+
+    get toggleSidePanelTooltip(): string
+    {
+        let tooltip = this._viewStateService.showSidePanel ? "Hide Side Panel" : "Show Side Panel";
+        let cmdOrCtrl = this.isWindows ? "Ctrl" : "Cmd";
+        let altKeyName = this.isFirefox ? this.isWindows ? "+Alt" : "+Option" : "";
+        return `${tooltip} (${cmdOrCtrl}${altKeyName}+B)`;
+    }
+
     onToggleSidePanel(): void
     {
         this._viewStateService.showSidePanel = !this._viewStateService.showSidePanel;

--- a/client/src/app/routes/dataset/analysis/analysis.component.ts
+++ b/client/src/app/routes/dataset/analysis/analysis.component.ts
@@ -406,17 +406,17 @@ export class AnalysisComponent implements OnInit, OnDestroy
     onKeydown(event: KeyboardEvent): void
     {
         let cmdOrCtrl = this.isWindows ? "Control" : "Meta";
+        let bOrAltB = this.isFirefox ? "∫" : "b";
 
         this._keyPresses.add(event.key);
         if(
-            (this._keyPresses.has(cmdOrCtrl) && this._keyPresses.has("b") && !this.isFirefox) || 
-            (this._keyPresses.has(cmdOrCtrl) && this._keyPresses.has("∫") && this.isFirefox)
+            (this._keyPresses.has(cmdOrCtrl) && this._keyPresses.has(bOrAltB))
         )
         {
             if(event.key === cmdOrCtrl)
             {
                 this._keyPresses.delete(cmdOrCtrl);
-                this._keyPresses.delete("B");
+                this._keyPresses.delete(bOrAltB);
             }
             this._keyPresses.delete(event.key);
 

--- a/client/src/app/routes/dataset/analysis/analysis.component.ts
+++ b/client/src/app/routes/dataset/analysis/analysis.component.ts
@@ -92,6 +92,8 @@ export class AnalysisComponent implements OnInit, OnDestroy
     //private _soloViewComponent = null;
     private _soloDialogRef = null;
 
+    private _keyPresses = new Set<string>();
+
     constructor(
         private _route: ActivatedRoute,
         private _router: Router,
@@ -388,6 +390,44 @@ export class AnalysisComponent implements OnInit, OnDestroy
                 this._underSpectrumComponents.push(comp);
             }
         }
+    }
+
+    get isWindows(): boolean
+    {
+        return navigator.userAgent.search("Windows") !== -1;
+    }
+
+    get isFirefox(): boolean
+    {
+        return !!navigator.userAgent.match(/firefox|fxios/i);
+    }
+
+    @HostListener("window:keydown", ["$event"])
+    onKeydown(event: KeyboardEvent): void
+    {
+        let cmdOrCtrl = this.isWindows ? "Control" : "Meta";
+
+        this._keyPresses.add(event.key);
+        if(
+            (this._keyPresses.has(cmdOrCtrl) && this._keyPresses.has("b") && !this.isFirefox) || 
+            (this._keyPresses.has(cmdOrCtrl) && this._keyPresses.has("∫") && this.isFirefox)
+        )
+        {
+            if(event.key === cmdOrCtrl)
+            {
+                this._keyPresses.delete(cmdOrCtrl);
+                this._keyPresses.delete("B");
+            }
+            this._keyPresses.delete(event.key);
+
+            this._viewStateService.showSidePanel = !this._viewStateService.showSidePanel;
+        }
+    }
+
+    @HostListener("window:keyup", ["$event"])
+    onKeyup(event: KeyboardEvent): void
+    {
+        this._keyPresses.delete(event.key);
     }
 
     // NOTE: there are ways to go from selector string to ComponentFactory:

--- a/client/src/app/routes/dataset/code-editor/code-editor.component.ts
+++ b/client/src/app/routes/dataset/code-editor/code-editor.component.ts
@@ -135,7 +135,8 @@ export class CodeEditorComponent extends ExpressionListGroupNames implements OnI
 
     public isPMCDataGridSolo: boolean = false;
 
-    private _keyPresses: { [key: string]: boolean } = {};
+    // private _keyPresses: { [key: string]: boolean } = {};
+    private _keyPresses: Set<string> = new Set<string>();
     
     private _fetchedExpression: boolean = false;
 
@@ -1926,59 +1927,50 @@ export class CodeEditorComponent extends ExpressionListGroupNames implements OnI
     onKeydown(event: KeyboardEvent): void
     {
         let cmdOrCtrl = this.isWindows ? "Control" : "Meta";
+        let bOrAltB = this.isFirefox ? "∫" : "b";
 
-        this._keyPresses[event.key] = true;
-        if((this._keyPresses[cmdOrCtrl] && this._keyPresses["Enter"]))
+        this._keyPresses.add(event.key);
+        if((this._keyPresses.has(cmdOrCtrl) && this._keyPresses.has("Enter")))
         {
             this.runExpression();
             if(event.key === cmdOrCtrl)
             {
-                this._keyPresses[cmdOrCtrl] = false;
-                this._keyPresses["Enter"] = false;
+                this._keyPresses.delete(cmdOrCtrl);
+                this._keyPresses.delete("Enter");
             }
-            this._keyPresses[event.key] = false;
+            this._keyPresses.delete(event.key);
         }
-        else if((this._keyPresses[cmdOrCtrl] && this._keyPresses["s"]))
+        else if((this._keyPresses.has(cmdOrCtrl) && this._keyPresses.has("s")))
         {
             this.onSave();
-            this._keyPresses[event.key] = false;
+            this._keyPresses.delete(event.key);
             if(event.key === cmdOrCtrl)
             {
-                this._keyPresses[cmdOrCtrl] = false;
-                this._keyPresses["s"] = false;
+                this._keyPresses.delete(cmdOrCtrl);
+                this._keyPresses.delete("s");
             }
             event.stopPropagation();
             event.stopImmediatePropagation();
             event.preventDefault();
         }
-        else if((this._keyPresses[cmdOrCtrl] && this._keyPresses["b"]) && !this.isFirefox)
+        else if((this._keyPresses.has(cmdOrCtrl) && this._keyPresses.has(bOrAltB)))
         {
             this.onToggleSidebar();
-            this._keyPresses[event.key] = false;
+            this._keyPresses.delete(event.key);
             if(event.key === cmdOrCtrl)
             {
-                this._keyPresses[cmdOrCtrl] = false;
-                this._keyPresses["b"] = false;
+                this._keyPresses.delete(cmdOrCtrl);
+                this._keyPresses.delete(bOrAltB);
             }
         }
-        else if((this._keyPresses[cmdOrCtrl] && this._keyPresses["∫"]) && this.isFirefox)
-        {
-            this.onToggleSidebar();
-            this._keyPresses[event.key] = false;
-            if(event.key === cmdOrCtrl)
-            {
-                this._keyPresses[cmdOrCtrl] = false;
-                this._keyPresses["∫"] = false;
-            }
-        }
-        else if((this._keyPresses[cmdOrCtrl] && this._keyPresses["\\"]))
+        else if((this._keyPresses.has(cmdOrCtrl) && this._keyPresses.has("\\")))
         {
             this.onToggleSplitScreen();
-            this._keyPresses[event.key] = false;
+            this._keyPresses.delete(event.key);
             if(event.key === cmdOrCtrl)
             {
-                this._keyPresses[cmdOrCtrl] = false;
-                this._keyPresses["\\"] = false;
+                this._keyPresses.delete(cmdOrCtrl);
+                this._keyPresses.delete("\\");
             }
         }
     }
@@ -1986,7 +1978,7 @@ export class CodeEditorComponent extends ExpressionListGroupNames implements OnI
     @HostListener("window:keyup", ["$event"])
     onKeyup(event: KeyboardEvent): void
     {
-        this._keyPresses[event.key] = false;
+        this._keyPresses.delete(event.key);
     }
 
     // NOTE: there are ways to go from selector string to ComponentFactory:


### PR DESCRIPTION
- Adds shortcut for toggling sidepanel on analysis page
- Adds tooltips to filter and "show shared" header buttons in analysis page sidepanel as well as to toggle button
- Refactors hotkeys to use a Set so that the dictionary object doesn't simply expand with every new keypress
  - Also refactors checks for firefox to make code more DRY
- Fixes bug with copying stderr and stdout on pmc grid, adds another check to ensure valid printable data for non table output