### PR TITLE
Hotfix for prod release - redirect /about to /public/about-us because…

### DIFF
--- a/client/src/app/app-routing.module.ts
+++ b/client/src/app/app-routing.module.ts
@@ -66,6 +66,9 @@ const APP_ROUTES: Routes = [
 
     { path: "", loadChildren: ()=>import("./modules/public-site/public-site.module").then(m=>m.PublicSiteModule) },
 
+    // Redirect the old about page here, lots of browsers are likely to have this saved/bookmarked
+    { path: "about", redirectTo: "public/about-us", pathMatch: "full" },
+
     // Authenticated pages
     {
         path: "",

--- a/client/src/app/modules/public-site/public-site.module.ts
+++ b/client/src/app/modules/public-site/public-site.module.ts
@@ -62,6 +62,7 @@ import { TeamListComponent } from "./components/atoms/team-list/team-list.compon
 const APP_ROUTES: Routes = [
     { path: "public", component: PublicPageComponent,
         children: [
+            { path: "", redirectTo: LandingRouteName, pathMatch: 'full' },
             { path: LandingRouteName, component: LandingPageComponent },
             { path: "workflow", component: WorkflowPageComponent },
             { path: "investigation", component: InvestigationPageComponent },
@@ -71,7 +72,6 @@ const APP_ROUTES: Routes = [
         ]
     },
     { path: "", redirectTo: "public/pixlise", pathMatch: "full" },
-    { path: "public", redirectTo: "public/pixlise", pathMatch: "full" },
 ];
 
 @NgModule({


### PR DESCRIPTION
… existing browsers probably have /about bookmarked. Also if ending up at /public, redirect to /public/pixlise #3464