### PR TITLE
Unknown Layer ID Bug Fix

### DIFF
--- a/client/src/app/UI/context-image-view-widget/layer-manager.ts
+++ b/client/src/app/UI/context-image-view-widget/layer-manager.ts
@@ -190,9 +190,16 @@ export class LayerManager
             {
                 // Look it up in our list that we created earlier
                 let layer = this._layers.getLayerById(source.id);
+
+                // HACK: This is a hack to fix a bug where we get a layer that doesn't exist in our list. This will be cleaned up in v4
+                // This code ideally should never be triggered, but has been seen in prod, possibly do to caching?
                 if(!layer)
                 {
-                    throw new Error("makeExpressionList failed for unknown id: "+source.id);
+                    console.error("makeExpressionList failed for unknown id:", source.id);
+                    SentryHelper.logException("makeExpressionList failed for unknown id: "+source.id, "LayerManager");
+                    // throw new Error("makeExpressionList failed for unknown id: "+source.id);
+
+                    return null;
                 }
                 return layer;
             }

--- a/client/src/app/models/ExpressionList.ts
+++ b/client/src/app/models/ExpressionList.ts
@@ -335,7 +335,13 @@ export class ExpressionListBuilder extends ExpressionListGroupNames
 
         for(let item of items)
         {
-            store.addLayer(makeLayer(item));
+            let layer = makeLayer(item);
+            if(!layer)
+            {
+                console.error("Could not make layer during makeLayers", item)
+                continue;
+            }
+            store.addLayer(layer);
         }
 
         // Run through the layers in the same order as makeExpressionList and form them
@@ -707,10 +713,18 @@ export class ExpressionListBuilder extends ExpressionListGroupNames
             {
                 let expr = exprLookup.get(orderedGroup[0]);
                 let layer = makeLayer(expr);
-                result.push(new LayerInfo(layer, orderedGroup.slice(1)));
-
-                // This is going to become the sub-layer list owner!
-                out_subLayerOwnerIDs.push(expr.id);
+                if(!layer)
+                {
+                    console.error("Could not make layer during extractMainExpressionsWithSubLayers for:", expr);
+                }
+                else
+                {
+                    result.push(new LayerInfo(layer, orderedGroup.slice(1)));
+    
+                    // This is going to become the sub-layer list owner!
+                    out_subLayerOwnerIDs.push(expr.id);
+                }
+                    
             }
         };
 
@@ -793,6 +807,11 @@ export class ExpressionListBuilder extends ExpressionListGroupNames
             if(expr)
             {
                 let layer = makeLayer(expr);
+                if(!layer)
+                {
+                    console.error("Could not make layer during includeElementRelatedBuiltInExpressions for:", expr);
+                    continue;
+                }
                 list.push(new LayerInfo(layer, subLayers));
 
                 out_subLayerOwnerIDs.push(ordered[0]);
@@ -869,12 +888,17 @@ export class ExpressionListBuilder extends ExpressionListGroupNames
         let layers: LayerInfo[] = [];
         for(let item of items)
         {
-            if(!this.showUnsavedExpressions && item?.id?.startsWith(DataExpressionId.UnsavedExpressionPrefix))
+            if(!this.showUnsavedExpressions && !item?.id || item.id.startsWith(DataExpressionId.UnsavedExpressionPrefix))
             {
                 continue;
             }
 
             let layer = makeLayer(item);
+            if(!layer)
+            {
+                console.error("Could not make layer during getItems for:", item);
+                continue;
+            }
             layer.isOutOfDate = !item?.isModuleListUpToDate || false;
             layers.push(new LayerInfo(layer, []));
         }
@@ -893,6 +917,11 @@ export class ExpressionListBuilder extends ExpressionListGroupNames
         for(let item of items)
         {
             let layer = makeLayer(item);
+            if(!layer)
+            {
+                console.error("Could not make layer during getRGBItems for:", item);
+                continue;
+            }
             result.push(
                 new RGBLayerInfo(
                     layer,


### PR DESCRIPTION
- Adds error handling in case makeLayer is called for a layer that is not tracked in the list of layers, logs to sentry, removes exception
- It's still unknown the exact case that causes this bug to occur. Possibly a caching related issue? However, it is non-breaking and recoverable, so this MR simply handles the edge case and removes the non-existent layer from the list. This should be more properly fixed in the V4 overhaul.