### PR TITLE
Feature/multi dataset key bug

### DIFF
--- a/client/src/app/modules/analysis/pages/analysis-page/analysis-page.component.ts
+++ b/client/src/app/modules/analysis/pages/analysis-page/analysis-page.component.ts
@@ -140,6 +140,11 @@ export class AnalysisPageComponent {
     this._keyPresses.delete(event.key);
   }
 
+  @HostListener("window:blur")
+  onWindowBlur(): void {
+    this._keyPresses.clear();
+  }
+
   @HostListener("window:resize", ["$event"])
   onResize() {
     // Window resized, notify all canvases

--- a/client/src/app/modules/roi/components/roi-item/roi-item.component.html
+++ b/client/src/app/modules/roi/components/roi-item/roi-item.component.html
@@ -69,7 +69,7 @@
       <action-button title="Delete this ROI" action="delete" confirmText="Are you sure you want to delete ROI: {{ name }}?" (onClick)="onDelete()"> </action-button>
       <share-ownership-item-button *ngIf="canEdit" [id]="summary?.id || ''" [type]="objectType" [ownershipSummary]="summary?.owner || null">
       </share-ownership-item-button>
-      <widget-settings-menu [settingsDialog]="roiShapePicker" #roiShapePickerButton>
+      <widget-settings-menu *ngIf="!isAllPointsROI" [settingsDialog]="roiShapePicker" #roiShapePickerButton>
         <icon-button title="Configure Shapes" icon="assets/button-icons/shapes.svg"> </icon-button>
       </widget-settings-menu>
       <widget-settings-menu [settingsDialog]="roiColorPicker" #roiColorPickerButton>
@@ -178,7 +178,7 @@
         [editable]="summary.owner?.canEdit || false"
         (onTagSelectionChanged)="onTagSelectionChanged($event)">
       </tag-picker>
-      <widget-settings-menu *ngIf="colorChangeOnly" [settingsDialog]="roiShapePicker" #roiShapePickerButton>
+      <widget-settings-menu *ngIf="colorChangeOnly && !isAllPointsROI" [settingsDialog]="roiShapePicker" #roiShapePickerButton>
         <icon-button title="Configure Shapes" icon="assets/button-icons/shapes.svg"> </icon-button>
       </widget-settings-menu>
       <widget-settings-menu *ngIf="colorChangeOnly" [settingsDialog]="roiColorPicker" #roiColorPickerButton>

--- a/client/src/app/modules/roi/components/roi-item/roi-item.component.ts
+++ b/client/src/app/modules/roi/components/roi-item/roi-item.component.ts
@@ -12,6 +12,7 @@ import { BeamSelection } from "src/app/modules/pixlisecore/models/beam-selection
 import { PixelSelection } from "src/app/modules/pixlisecore/models/pixel-selection";
 import { UsersService } from "src/app/modules/settings/services/users.service";
 import { UserInfo } from "src/app/generated-protos/user";
+import { PredefinedROIID } from "../../../../models/RegionOfInterest";
 
 export type SubItemOptionSection = {
   title: string;
@@ -271,6 +272,10 @@ export class ROIItemComponent implements OnInit, OnDestroy, OnChanges {
 
   get additionalColorOptions(): ColourOption[] {
     return this.colorOptions.filter(option => !option.colourBlindSafe);
+  }
+
+  get isAllPointsROI(): boolean {
+    return PredefinedROIID.isAllPointsROI(this.summary.id);
   }
 
   onSelectColour(colour: ColourOption) {

--- a/client/src/app/modules/scatterplots/base/model.ts
+++ b/client/src/app/modules/scatterplots/base/model.ts
@@ -322,7 +322,7 @@ export abstract class NaryChartModel<RawModel extends NaryData, DrawModel extend
             roiIdForKey = "";
           }
 
-          if (!this.keyItems.find(key => key.id == roiIdForKey)) {
+          if (!roiIdForKey || !this.keyItems.find(key => key.id == roiIdForKey)) {
             this.keyItems.push(new WidgetKeyItem(roiIdForKey, region.region.name, region.displaySettings.colour, null, region.displaySettings.shape));
           }
         }


### PR DESCRIPTION
- Fixed issue where key wasn't showing up for all datasets if multiple All Points regions were selected
- The region color changer in the ROI picker now updates the dataset color if you change the color for the All Points region
  - Hides the shapes picker for All Points as this is unsupported
- Fixed edge case where if you held down "Cmd" (or "Ctrl" on Windows) and then clicked off the page, when you went back, pressing "B" would trigger the sidebar to toggle
