### PR TITLE
Fixing context image drawer cache bug - effectively disables caching …

### DIFF
--- a/client/src/app/modules/image-viewers/widgets/context-image/context-image.component.ts
+++ b/client/src/app/modules/image-viewers/widgets/context-image/context-image.component.ts
@@ -747,6 +747,7 @@ export class ContextImageComponent extends BaseWidgetModel implements OnInit, On
   }
 
   reDraw() {
+    this.mdl.drawModel.drawnData = null;
     this.mdl.needsDraw$.next();
   }
 


### PR DESCRIPTION
…now, every redraw() call in context image invalidates the cache. Some instances may not do this so it might still be a perf improvement