### PR TITLE
Use new cache key for memoisation of expression outputs - stores spec…

### DIFF
--- a/client/src/app/modules/analysis/services/exporter.service.ts
+++ b/client/src/app/modules/analysis/services/exporter.service.ts
@@ -210,7 +210,7 @@ export class DataExporterService {
     const requests: [Observable<ScanBeamLocationsResp>, Observable<ScanEntryResp>, Observable<SpectrumResp>, Observable<ScanMetaLabelsAndTypesResp>] = [
       this._cachedDataService.getScanBeamLocations(ScanBeamLocationsReq.create({ scanId: scanId })),
       this._cachedDataService.getScanEntry(ScanEntryReq.create({ scanId: scanId })),
-      this._spectrumDataService.getSpectrum(scanId, null, true, true),
+      this._spectrumDataService.getSpectra(scanId, null, true, true),
       this._cachedDataService.getScanMetaLabelsAndTypes(ScanMetaLabelsAndTypesReq.create({ scanId })),
     ];
 
@@ -382,7 +382,7 @@ msa += `#XPOSITION   : 0.000
   getBulkSumMaxSpectra(scanId: string, roiIds: string[]): Observable<WidgetExportData> {
     const requests: Observable<ScanMetaLabelsAndTypesResp | SpectrumResp | RegionOfInterestGetResp>[] = [
       this._cachedDataService.getScanMetaLabelsAndTypes(ScanMetaLabelsAndTypesReq.create({ scanId })),
-      this._spectrumDataService.getSpectrum(scanId, roiIds.length > 0 ? null : [], true, true),
+      this._spectrumDataService.getSpectra(scanId, roiIds.length > 0 ? null : [], true, true),
     ];
 
     for (const roiId of roiIds) {

--- a/client/src/app/modules/pixlisecore/models/expression-data-source.ts
+++ b/client/src/app/modules/pixlisecore/models/expression-data-source.ts
@@ -248,7 +248,7 @@ export class ExpressionDataSource
     }
 
     // NOTE: We need ALL spectra because the functions that access this sum across all spectra
-    return this._spectrumDataService.getSpectrum(this._scanId, null, false, false);
+    return this._spectrumDataService.getSpectra(this._scanId, null, false, false);
   }
 
   private getDiffractionPeakManualList(): Observable<DiffractionPeakManualListResp> {

--- a/client/src/app/modules/pixlisecore/services/energy-calibration.service.ts
+++ b/client/src/app/modules/pixlisecore/services/energy-calibration.service.ts
@@ -88,7 +88,7 @@ export class EnergyCalibrationService {
   getScanCalibration(scanId: string): Observable<SpectrumEnergyCalibration[]> {
     return combineLatest([
       this._cachedDataService.getScanMetaLabelsAndTypes(ScanMetaLabelsAndTypesReq.create({ scanId: scanId })),
-      this._spectrumDataService.getSpectrum(scanId, [], true, false),
+      this._spectrumDataService.getSpectra(scanId, [], true, false),
     ]).pipe(
       map(values => {
         const metaResp = values[0] as ScanMetaLabelsAndTypesResp;

--- a/client/src/app/modules/pixlisecore/services/spectrum-data.service.ts
+++ b/client/src/app/modules/pixlisecore/services/spectrum-data.service.ts
@@ -55,7 +55,7 @@ export class SpectrumDataService {
   }
 
   // If called with indexes==null, we won't receive per-PMC spectra. If indexes==[] or an array with numbers, the spectra for those PMCs will be returned
-  getSpectrum(scanId: string, indexes: number[] | null, bulkSum: boolean, maxValue: boolean): Observable<SpectrumResp> {
+  getSpectra(scanId: string, indexes: number[] | null, bulkSum: boolean, maxValue: boolean): Observable<SpectrumResp> {
     // Get the scans meta data so we know what indexes exist
     return this._cachedDataService.getScanList(ScanListReq.create({ searchFilters: { scanId } })).pipe(
       switchMap((scanListResp: ScanListResp) => {
@@ -75,7 +75,7 @@ export class SpectrumDataService {
             if (this._outstandingReq !== null) {
               return this._outstandingReq.pipe(
                 switchMap(result => {
-                  return this.getSpectrum(scanId, indexes, bulkSum, maxValue);
+                  return this.getSpectra(scanId, indexes, bulkSum, maxValue);
                 })
               );
             }

--- a/client/src/app/modules/spectrum/widgets/spectrum-chart-widget/spectrum-chart-widget.component.ts
+++ b/client/src/app/modules/spectrum/widgets/spectrum-chart-widget/spectrum-chart-widget.component.ts
@@ -778,7 +778,7 @@ export class SpectrumChartWidgetComponent extends BaseWidgetModel implements OnI
           }
 
           combineLatest([
-            this._spectrumDataService.getSpectrum(roi.region.scanId, idxs, true, true),
+            this._spectrumDataService.getSpectra(roi.region.scanId, idxs, true, true),
             this._cachedDataService.getScanList(
               ScanListReq.create({
                 searchFilters: { scanId: roi.region.scanId },


### PR DESCRIPTION
…trum normal, dwell counts and import time stamp (new field added to API, but if it's 0, it should still work based on normal/dwell count)