### PR TITLE
Attempt to fix context image issues - rolled back broken fix for expo…

### DIFF
--- a/client/src/app/modules/image-viewers/widgets/multi-channel-viewer/multi-channel-viewer-model.ts
+++ b/client/src/app/modules/image-viewers/widgets/multi-channel-viewer/multi-channel-viewer-model.ts
@@ -1,4 +1,4 @@
-import { combineLatest, Subject } from "rxjs";
+import { combineLatest, Observable, of, Subject } from "rxjs";
 import { MinMax } from "src/app/models/BasicTypes";
 import { RGBUImage } from "src/app/models/RGBUImage";
 import { CanvasDrawNotifier, CanvasParams } from "src/app/modules/widget/components/interactive-canvas/interactive-canvas.component";
@@ -44,13 +44,14 @@ export class MultiChannelViewerModel implements CanvasDrawNotifier {
     return this.raw != null;
   }
 
-  recalcDisplayDataIfNeeded(canvasParams: CanvasParams): void {
+  recalcDisplayDataIfNeeded(canvasParams: CanvasParams): Observable<void> {
     if (this._recalcNeeded || !this._lastCalcCanvasParams || !this._lastCalcCanvasParams.equals(canvasParams)) {
       this.regenerate();
 
       this._lastCalcCanvasParams = canvasParams;
       this._recalcNeeded = false;
     }
+    return of(void 0);
   }
 
   setRecalcNeeded() {

--- a/client/src/app/modules/pixlisecore/services/memoisation.service.ts
+++ b/client/src/app/modules/pixlisecore/services/memoisation.service.ts
@@ -40,7 +40,7 @@ export class MemoisationService {
   memoise(key: string, data: Uint8Array): Observable<MemoisedItem> {
     if (environment.skipMemoizeKeys.indexOf(key) > -1) {
       console.warn("Skipping memoisation of: " + key);
-      return of();
+      return of(MemoisedItem.create({ key: key, data: data }));
     }
 
     // Only memoise if it's changed
@@ -50,7 +50,7 @@ export class MemoisationService {
       if (idx < 0) {
         // Stop here, we've already got this memoised
         console.warn("Already memoised: " + key);
-        return of();
+        return of(MemoisedItem.create({ key: key, data: data }));
       } else {
         SentryHelper.logMsg(false, `Memoised data ${key} changed at idx ${idx}`);
       }

--- a/client/src/app/modules/scatterplots/base/cached-drawer.ts
+++ b/client/src/app/modules/scatterplots/base/cached-drawer.ts
@@ -9,44 +9,44 @@ export abstract class CachedCanvasChartDrawer implements CanvasDrawer {
   // Where we do our actual drawing... This wraps recalc if needed and drawing to cached layer (in offscreen canvas)
   // and allows derived classes to do drawing before and after the cached layer is blit-ed in
   draw(screenContext: CanvasRenderingContext2D, drawParams: CanvasDrawParameters): void {
-    this.mdl.recalcDisplayDataIfNeeded(drawParams.drawViewport, screenContext);
+    this.mdl.recalcDisplayDataIfNeeded(drawParams.drawViewport, screenContext).subscribe(() => {
+      this.drawPreData(screenContext, drawParams);
 
-    this.drawPreData(screenContext, drawParams);
+      // Draw data points
+      if (this.mdl.drawModel) {
+        const drawMdl = this.mdl.drawModel;
+        if (!drawMdl.drawnData && this.mdl.hasRawData()) {
+          drawMdl.drawnData = new OffscreenCanvas(
+            drawParams.drawViewport.width * drawParams.drawViewport.dpi,
+            drawParams.drawViewport.height * drawParams.drawViewport.dpi
+          );
 
-    // Draw data points
-    if (this.mdl.drawModel) {
-      const drawMdl = this.mdl.drawModel;
-      if (!drawMdl.drawnData && this.mdl.hasRawData()) {
-        drawMdl.drawnData = new OffscreenCanvas(
-          drawParams.drawViewport.width * drawParams.drawViewport.dpi,
-          drawParams.drawViewport.height * drawParams.drawViewport.dpi
-        );
+          const offscreenContext = drawMdl.drawnData.getContext("2d");
+          if (offscreenContext) {
+            offscreenContext.scale(drawParams.drawViewport.dpi, drawParams.drawViewport.dpi);
+            // Render data to an image which is cached and drawn as needed
+            this.drawData(offscreenContext, drawParams);
+          }
+        }
 
-        const offscreenContext = drawMdl.drawnData.getContext("2d");
-        if (offscreenContext) {
-          offscreenContext.scale(drawParams.drawViewport.dpi, drawParams.drawViewport.dpi);
-          // Render data to an image which is cached and drawn as needed
-          this.drawData(offscreenContext, drawParams);
+        if (drawMdl.drawnData) {
+          // Draw previously rendered points...
+          screenContext.drawImage(
+            drawMdl.drawnData,
+            0,
+            0,
+            drawMdl.drawnData.width,
+            drawMdl.drawnData.height,
+            0,
+            0,
+            drawParams.drawViewport.width,
+            drawParams.drawViewport.height
+          );
         }
       }
 
-      if (drawMdl.drawnData) {
-        // Draw previously rendered points...
-        screenContext.drawImage(
-          drawMdl.drawnData,
-          0,
-          0,
-          drawMdl.drawnData.width,
-          drawMdl.drawnData.height,
-          0,
-          0,
-          drawParams.drawViewport.width,
-          drawParams.drawViewport.height
-        );
-      }
-    }
-
-    this.drawPostData(screenContext, drawParams);
+      this.drawPostData(screenContext, drawParams);
+    });
   }
 
   abstract drawPreData(screenContext: CanvasRenderingContext2D, drawParams: CanvasDrawParameters): void;

--- a/client/src/app/modules/scatterplots/base/model-interfaces.ts
+++ b/client/src/app/modules/scatterplots/base/model-interfaces.ts
@@ -1,5 +1,6 @@
 import { Point, PointWithRayLabel } from "src/app/models/Geometry";
 import { CanvasParams } from "../../widget/components/interactive-canvas/interactive-canvas.component";
+import { Observable } from "rxjs";
 
 // For use with cached drawer
 export interface BaseChartDrawModel {
@@ -7,7 +8,7 @@ export interface BaseChartDrawModel {
 }
 
 export interface BaseChartModel {
-  recalcDisplayDataIfNeeded(canvasParams: CanvasParams, screenContext?: CanvasRenderingContext2D): void;
+  recalcDisplayDataIfNeeded(canvasParams: CanvasParams, screenContext?: CanvasRenderingContext2D): Observable<void>;
   drawModel: BaseChartDrawModel;
   hasRawData(): boolean;
 }

--- a/client/src/app/modules/scatterplots/base/model.ts
+++ b/client/src/app/modules/scatterplots/base/model.ts
@@ -1,4 +1,4 @@
-import { Subject } from "rxjs";
+import { Observable, of, Subject } from "rxjs";
 import { PMCDataValues } from "src/app/expression-language/data-values";
 import { getExpressionShortDisplayName } from "src/app/expression-language/expression-short-name";
 import { MinMax } from "src/app/models/BasicTypes";
@@ -217,13 +217,14 @@ export abstract class NaryChartModel<RawModel extends NaryData, DrawModel extend
     }
   }
 
-  recalcDisplayDataIfNeeded(canvasParams: CanvasParams): void {
+  recalcDisplayDataIfNeeded(canvasParams: CanvasParams): Observable<void> {
     // Regenerate draw points if required (if canvas viewport changes, or if we haven't generated them yet)
     if (this._recalcNeeded || !this._lastCalcCanvasParams || !this._lastCalcCanvasParams.equals(canvasParams)) {
       this.regenerateDrawModel(this._raw, canvasParams);
       this._lastCalcCanvasParams = canvasParams;
       this._recalcNeeded = false;
     }
+    return of(void 0);
   }
 
   // For now an ugly solution that makes this compile...

--- a/client/src/app/modules/scatterplots/widgets/chord-diagram-widget/chord-drawer.ts
+++ b/client/src/app/modules/scatterplots/widgets/chord-diagram-widget/chord-drawer.ts
@@ -18,9 +18,9 @@ export class ChordDiagramDrawer implements CanvasDrawer {
   constructor(protected _mdl: ChordDiagramModel) {}
 
   draw(screenContext: CanvasRenderingContext2D, drawParams: CanvasDrawParameters): void {
-    this._mdl.recalcDisplayDataIfNeeded(drawParams.drawViewport);
-
-    this.drawChordDiagram(this._mdl.drawModel, screenContext, drawParams.drawViewport);
+    this._mdl.recalcDisplayDataIfNeeded(drawParams.drawViewport).subscribe(() => {
+      this.drawChordDiagram(this._mdl.drawModel, screenContext, drawParams.drawViewport);
+    });
   }
 
   private drawChordDiagram(drawModel: ChordDiagramDrawModel, screenContext: CanvasRenderingContext2D, viewport: CanvasParams): void {

--- a/client/src/app/modules/scatterplots/widgets/chord-diagram-widget/chord-interaction.ts
+++ b/client/src/app/modules/scatterplots/widgets/chord-diagram-widget/chord-interaction.ts
@@ -50,7 +50,7 @@ export class ChordDiagramInteraction implements CanvasInteractionHandler {
   }
 
   mouseEvent(event: CanvasMouseEvent): CanvasInteractionResult {
-    this._mdl.recalcDisplayDataIfNeeded(event.canvasParams);
+    this._mdl.recalcDisplayDataIfNeeded(event.canvasParams).subscribe();
 
     if (event.eventId == CanvasMouseEventId.MOUSE_MOVE) {
       const hoverNode = this.checkHoverNode(event.canvasPoint);

--- a/client/src/app/modules/scatterplots/widgets/chord-diagram-widget/chord-model.ts
+++ b/client/src/app/modules/scatterplots/widgets/chord-diagram-widget/chord-model.ts
@@ -2,7 +2,7 @@ import { MinMax } from "src/app/models/BasicTypes";
 import { CanvasDrawNotifier, CanvasParams } from "src/app/modules/widget/components/interactive-canvas/interactive-canvas.component";
 import { Point, Rect } from "src/app/models/Geometry";
 import { CANVAS_FONT_SIZE, CANVAS_FONT_WIDTH_PERCENT } from "src/app/utils/drawing";
-import { Subject } from "rxjs";
+import { Observable, of, Subject } from "rxjs";
 import { WidgetDataIds, ScanDataIds } from "src/app/modules/pixlisecore/models/widget-data-source";
 import { CursorId } from "src/app/modules/widget/components/interactive-canvas/cursor-id";
 import { PMCDataValues } from "src/app/expression-language/data-values";
@@ -75,13 +75,14 @@ export class ChordDiagramModel implements CanvasDrawNotifier {
     this._recalcNeeded = true;
   }
 
-  recalcDisplayDataIfNeeded(canvasParams: CanvasParams): void {
+  recalcDisplayDataIfNeeded(canvasParams: CanvasParams): Observable<void> {
     // Regenerate draw points if required (if canvas viewport changes, or if we haven't generated them yet)
     if (this._recalcNeeded || !this._lastCalcCanvasParams || !this._lastCalcCanvasParams.equals(canvasParams)) {
       this._drawModel.regenerate(this._raw, canvasParams);
       this._lastCalcCanvasParams = canvasParams;
       this._recalcNeeded = false;
     }
+    return of(void 0);
   }
 
   // Returns error msg if one is generated

--- a/client/src/app/modules/scatterplots/widgets/histogram-widget/histogram-interaction.ts
+++ b/client/src/app/modules/scatterplots/widgets/histogram-widget/histogram-interaction.ts
@@ -41,7 +41,7 @@ export class HistogramToolHost implements CanvasInteractionHandler {
   constructor(private _mdl: HistogramModel) {}
 
   mouseEvent(event: CanvasMouseEvent): CanvasInteractionResult {
-    this._mdl.recalcDisplayDataIfNeeded(event.canvasParams);
+    this._mdl.recalcDisplayDataIfNeeded(event.canvasParams).subscribe();
 
     if (event.eventId == CanvasMouseEventId.MOUSE_MOVE) {
       // Hover handling if mouse is over a bar

--- a/client/src/app/modules/scatterplots/widgets/histogram-widget/histogram-model.ts
+++ b/client/src/app/modules/scatterplots/widgets/histogram-widget/histogram-model.ts
@@ -1,4 +1,4 @@
-import { Subject } from "rxjs";
+import { Observable, of, Subject } from "rxjs";
 import { MinMax } from "src/app/models/BasicTypes";
 import { Point, Rect } from "src/app/models/Geometry";
 import { ChartAxis, LabelledChartAxis, LinearChartAxis, LogarithmicChartAxis } from "src/app/modules/widget/components/interactive-canvas/chart-axis";
@@ -70,13 +70,14 @@ export class HistogramModel implements CanvasDrawNotifier, BaseChartModel {
     this.hoverPoint = pt;
   }
 
-  recalcDisplayDataIfNeeded(canvasParams: CanvasParams): void {
+  recalcDisplayDataIfNeeded(canvasParams: CanvasParams): Observable<void> {
     // Regenerate draw points if required (if canvas viewport changes, or if we haven't generated them yet)
     if (this._recalcNeeded || !this._lastCalcCanvasParams || !this._lastCalcCanvasParams.equals(canvasParams)) {
       this._drawModel.regenerate(this._raw, this.logScale, canvasParams);
       this._lastCalcCanvasParams = canvasParams;
       this._recalcNeeded = false;
     }
+    return of(void 0);
   }
 
   // Returns error message if one is generated

--- a/client/src/app/modules/scatterplots/widgets/rgbu-plot-widget/rgbu-plot-model.ts
+++ b/client/src/app/modules/scatterplots/widgets/rgbu-plot-widget/rgbu-plot-model.ts
@@ -40,7 +40,7 @@ import { Colours, RGBA, ColourRamp } from "src/app/utils/colours";
 import { PLOT_POINTS_SIZE, HOVER_POINT_RADIUS } from "src/app/utils/drawing";
 import { RGBUMineralPoint, RGBUPlotData, RGBUAxisUnit, RGBURatioPoint, ROICount, RGBUMineralRatios } from "./rgbu-plot-data";
 import { BeamSelection } from "src/app/modules/pixlisecore/models/beam-selection";
-import { Subject } from "rxjs";
+import { Observable, of, Subject } from "rxjs";
 import { BaseChartModel } from "../../base/model-interfaces";
 import { SelectionHistoryItem } from "src/app/modules/pixlisecore/services/selection.service";
 import { RegionSettings } from "src/app/modules/roi/models/roi-region";
@@ -313,7 +313,7 @@ export class RGBUPlotModel implements CanvasDrawNotifier, BaseChartModel {
     return rgbuPlotData;
   }
 
-  recalcDisplayDataIfNeeded(canvasParams: CanvasParams, screenContext: CanvasRenderingContext2D): void {
+  recalcDisplayDataIfNeeded(canvasParams: CanvasParams, screenContext: CanvasRenderingContext2D): Observable<void> {
     // Regenerate draw points if required (if canvas viewport changes, or if we haven't generated them yet)
     if (this._recalcNeeded || !this._lastCalcCanvasParams || !this._lastCalcCanvasParams.equals(canvasParams)) {
       // Calculate the points
@@ -330,7 +330,7 @@ export class RGBUPlotModel implements CanvasDrawNotifier, BaseChartModel {
         this.initAxes(canvasParams, panZoom, 0);
 
         if (!this._xAxis || !this._yAxis || !screenContext) {
-          return;
+          return of(void 0);
         }
 
         // All this for variable y-axis label widths!!
@@ -347,6 +347,7 @@ export class RGBUPlotModel implements CanvasDrawNotifier, BaseChartModel {
         this._recalcNeeded = false;
       }
     }
+    return of(void 0);
   }
 
   private initAxes(canvasParams: CanvasParams, transform: PanZoom, leftAxisLabelWidthPx: number): void {

--- a/client/src/app/modules/spectrum/widgets/spectrum-chart-widget/spectrum-model-interface.ts
+++ b/client/src/app/modules/spectrum/widgets/spectrum-chart-widget/spectrum-model-interface.ts
@@ -27,7 +27,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import { Subject } from "rxjs";
+import { Observable, Subject } from "rxjs";
 import { MinMax } from "src/app/models/BasicTypes";
 import { Rect } from "src/app/models/Geometry";
 import { ChartAxis } from "src/app/modules/widget/components/interactive-canvas/chart-axis";
@@ -81,7 +81,7 @@ export interface ISpectrumChartModel {
 
   transform: PanZoom;
 
-  recalcDisplayDataIfNeeded(viewport: CanvasParams): void;
+  recalcDisplayDataIfNeeded(viewport: CanvasParams): Observable<void>;
 
   needsDraw$: Subject<void>;
 

--- a/client/src/app/modules/spectrum/widgets/spectrum-chart-widget/spectrum-model.ts
+++ b/client/src/app/modules/spectrum/widgets/spectrum-chart-widget/spectrum-model.ts
@@ -27,7 +27,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import { BehaviorSubject, ReplaySubject, Subject } from "rxjs";
+import { BehaviorSubject, Observable, of, ReplaySubject, Subject } from "rxjs";
 import { ObjectCreator, MinMax, SpectrumEnergyCalibration } from "src/app/models/BasicTypes";
 import { Rect } from "src/app/models/Geometry";
 import { PredefinedROIID } from "src/app/models/RegionOfInterest";
@@ -927,13 +927,14 @@ export class SpectrumChartModel implements ISpectrumChartModel, CanvasDrawNotifi
   }
 
   // Rebuilding this models display data
-  recalcDisplayDataIfNeeded(canvasParams: CanvasParams): void {
+  recalcDisplayDataIfNeeded(canvasParams: CanvasParams): Observable<void> {
     // Regenerate draw points if required (if canvas viewport changes, or if we haven't generated them yet)
     if (this._recalcNeeded || !this._lastCalcCanvasParams || !this._lastCalcCanvasParams.equals(canvasParams)) {
       this.regenerateDrawModel(canvasParams);
       this._lastCalcCanvasParams = canvasParams;
       this._recalcNeeded = false;
     }
+    return of(void 0);
   }
 
   private regenerateDrawModel(viewport: CanvasParams) {


### PR DESCRIPTION
…rt of TIF images, realised that recalcDisplayDataIfNeeded() needs to return an Observable for the special case in Context Images where calling drawModel.regenerate() returns an Observable because of image loading on the fly. The previous fix tried to recycle the image from the existing draw model (when creating a new one) and this worked for TIF export but in the context image at runtime this didnt trigger a reload of the RGBU image if channels changed or whatever. The callers of regenerate() ended up triggering an image load, then continuing on drawing a null image. This is the 'correct' fix for that issue, and potentially fixes issues everywhere. Requires some more verification