### PR TITLE
Fixed docker warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY ./client/dist/pixlise /usr/share/nginx/html
 # shouldn't happen because we have a package.json script for prebuild (which does run)
 # that copies the change log already. Hopefully this will make it so we don't find this
 # happening again
-copy ./client/CHANGELOG.md /usr/share/nginx/html/assets/
+COPY ./client/CHANGELOG.md /usr/share/nginx/html/assets/
 
 COPY ./scripts/nginx.conf /etc/nginx/conf.d/default.conf
 


### PR DESCRIPTION
Fixing docker warning, also attempting version bump in dev (MINOR) version change 4.72.x to 4.73.x