### PR TITLE
Moved back-end lua expression running functionality so it only sends …

### DIFF
--- a/client/src/app/modules/pixlisecore/services/apidata.service.ts
+++ b/client/src/app/modules/pixlisecore/services/apidata.service.ts
@@ -7,8 +7,10 @@ import { getMessageName, WSError, WSMessageHandler, WSOustandingReq } from "./ws
 import { randomString } from "src/app/utils/utils";
 
 import * as _m0 from "protobufjs/minimal";
-import { Subject, Subscription, interval } from "rxjs";
+import { Observable, Subject, Subscriber, Subscription, interval, map, throwError, timeout } from "rxjs";
 import { environment } from "src/environments/environment";
+import { L } from "node_modules/@angular/cdk/a11y-module.d--J1yhM7R";
+import { JobStatus, JobStatus_Status } from "src/app/generated-protos/job";
 
 const TIMEOUT_CHECK_INTERVAL_MS = 3000;
 const MESSAGE_TIMEOUT_MS = environment.wsTimeout;
@@ -34,6 +36,8 @@ export class APIDataService extends WSMessageHandler implements OnDestroy {
   // doesnt have to restart). If it overflows MAX_INT, it loops around, that's ok! We just make sure our counter
   // also restarts at MAX_INT
   private _lastMsgId = 0;
+
+  private _jobWaiters = new Map<string, Subscriber<JobStatus>[]>();
 
   protected nextMsgId() {
     this._lastMsgId++;
@@ -84,6 +88,23 @@ export class APIDataService extends WSMessageHandler implements OnDestroy {
           this.stopTimeoutChecks();
         },
       });
+
+    this.jobListUpd$.subscribe(upd => {
+        if (upd && upd.job && (upd.job.status == JobStatus_Status.COMPLETE || upd.job.status == JobStatus_Status.ERROR)) {
+          // See who's waiting for it to complete (or error)
+          const waiters = this._jobWaiters.get(upd.job.jobId);
+          if (waiters) {
+            // Notify everyone!
+            for (let waiter of waiters) {
+              waiter.next(upd.job);
+            }
+
+            // No longer waiting on this
+            this._jobWaiters.delete(upd.job.jobId);
+          }
+        }
+      }
+    );
   }
 
   private stopTimeoutChecks() {
@@ -269,5 +290,21 @@ export class APIDataService extends WSMessageHandler implements OnDestroy {
       this.outstandingRequests$.next(msg);
       this._lastOutstandingRequestInfo = msg;
     }
+  }
+
+  // Assists with listening for expression job completion
+  waitForJobCompletion(id: string): Observable<JobStatus> {
+    return new Observable<JobStatus>(observer => {
+      if (!this._jobWaiters.get(id)) {
+        this._jobWaiters.set(id, []);
+      }
+
+      const waiters = this._jobWaiters.get(id)!;
+
+      // Add a waiter for it
+      waiters.push(observer);
+    }).pipe(
+      timeout({ each: environment.wsTimeout, with: () => throwError(()=>new Error(`expression job ${id} did not complete within ${environment.wsTimeout/1000}sec`))})
+    );
   }
 }

--- a/client/src/app/modules/pixlisecore/services/widget-data.service.ts
+++ b/client/src/app/modules/pixlisecore/services/widget-data.service.ts
@@ -63,8 +63,9 @@ import { ExpressionMemoisationService } from "./expression-memoisation.service";
 import { AuthService, User } from "@auth0/auth0-angular";
 import { AnalysisLayoutService } from "../services/analysis-layout.service";
 import { DataModuleVersionWithRef, DataSourceParams, DataUnit, LoadedSources, RegionDataResultItem, RegionDataResults, WidgetError } from "../models/widget-data-source";
-import { ExpressionCalculateReq, ExpressionCalculateResp } from "src/app/generated-protos/expression-calculate-msgs";
 import { DataSourceParams as APIDataSourceParams, DataUnit as APIDataUnit } from "src/app/generated-protos/expression-calculate";
+import { ExpressionOutputReq } from "src/app/generated-protos/expression-calculate-msgs";
+import { JobStatus_Status } from "src/app/generated-protos/job";
 
 
 @Injectable({
@@ -106,21 +107,6 @@ export class WidgetDataService {
       return of(new RegionDataResults([], "No expressions to calculate"));
     }
 
-    if (environment.runExpressionsOnBackEnd) {
-      // Check if we have any predefined expressions, if any, we run it locally
-      let cantRunOnBackEnd = 0;
-      for (const w of what) {
-        if (DataExpressionId.isPredefinedExpression(w.exprId) || DataExpressionId.isUnsavedExpressionId(w.exprId)) {
-          cantRunOnBackEnd++;
-        }
-      }
-
-      if (cantRunOnBackEnd <= 0) {
-        // Just send it off and wait for a response. Wild huh?
-        return this.runOnBackend(what);
-      }
-    }
-
     // Query each one separately and combine results at the end
     const exprResult$: Observable<DataQueryResult>[] = [];
     for (const query of what) {
@@ -148,99 +134,6 @@ export class WidgetDataService {
         // TODO: make it so getData() never throws an error!
         // return new RegionDataResults([], err);
         throw err;
-      })
-    );
-  }
-
-  private runOnBackend(what: DataSourceParams[]): Observable<RegionDataResults> {
-    // First, we convert data types to the API versions...
-    // TODO: Eventually get rid of this!
-    const reqs: APIDataSourceParams[] = [];
-    for (let item of what) {
-      let apiUnit: APIDataUnit = APIDataUnit.UNIT_DEFAULT;
-      switch(item.units) {
-        case DataUnit.UNIT_MMOL:
-          apiUnit = APIDataUnit.UNIT_MMOL;
-          break;
-        case DataUnit.UNIT_PPM:
-          apiUnit = APIDataUnit.UNIT_PPM;
-          break;
-      }
-
-      reqs.push(APIDataSourceParams.create({
-        scanId: item.scanId,
-        quantId: item.quantId,
-        expressionId: item.exprId,
-        roiId: item.roiId,
-        units: apiUnit,
-      }));
-    }
-
-    return this._dataService.sendExpressionCalculateRequest(ExpressionCalculateReq.create({requests: reqs})).pipe(
-      map((resp: ExpressionCalculateResp) => {
-        // Convert data types back to client-usable versions...
-        // TODO: Eventually get rid of this!
-        let respResultItems: RegionDataResultItem[] = [];
-
-        // Decode each item
-        if (resp.result?.queryResults && resp.result?.queryResults.length > 0) {
-          for (let item of resp.result?.queryResults) {
-            const values: PMCDataValue[] = [];
-            if (item.exprResult?.resultValues) {
-              for (const v of item.exprResult?.resultValues.values) {
-                values.push(new PMCDataValue(v.pmc, v.value, v.isUndefined, v.label));
-              }
-            }
-
-            const result = new DataQueryResult(
-              PMCDataValues.makeWithValues(values),
-              item.exprResult?.isPMCTable || true,
-              [], // dataRequired
-              0, // runtimeMs
-              "", // stdout
-              "", // stderr
-              new Map<string, PMCDataValues>(), // recordedExpressionInputs
-              new Map<string, string>(), // recorded expression values
-              "", // errorMsg
-              item.exprResult?.expression
-            );
-
-            let unit: DataUnit = DataUnit.UNIT_DEFAULT;
-            switch(item.query?.units) {
-              case APIDataUnit.UNIT_MMOL:
-                unit = DataUnit.UNIT_MMOL;
-                break;
-              case APIDataUnit.UNIT_PPM:
-                unit = DataUnit.UNIT_PPM;
-                break;
-              case APIDataUnit.UNIT_DEFAULT:
-                unit = DataUnit.UNIT_DEFAULT;
-                break;
-            }
-
-            const query = new DataSourceParams(
-              item.query?.scanId || "",
-              item.query?.expressionId || "",
-              item.query?.quantId || "",
-              item.query?.roiId || "",
-              unit,
-              null
-            );
-
-            respResultItems.push(new RegionDataResultItem(
-              result,
-              item.error.length > 0 ? new WidgetError(item.error, "") : null,
-              item.warning,
-              item.expression || null,
-              null,//item.region,
-              query,
-              item.isPMCTable,
-            ));
-          }
-        }
-
-        let respResult = new RegionDataResults(respResultItems, resp.result?.error || "");
-        return respResult;
       })
     );
   }
@@ -353,6 +246,66 @@ export class WidgetDataService {
   }
 
   private getDataSingle(query: DataSourceParams, allowAnyResponse: boolean): Observable<DataQueryResult> {
+    if (!environment.runExpressionsOnBackEnd || DataExpressionId.isPredefinedExpression(query.exprId) || DataExpressionId.isUnsavedExpressionId(query.exprId)) {
+      return this.getMemoisedData(query, allowAnyResponse);
+    }
+
+    console.warn(`getDataSingle for expression: ${query.exprId}...`);
+    // We go straight to the back-end for these - it gives us a cache key and tells us if it's available yet
+    return this._dataService.sendExpressionOutputRequest(ExpressionOutputReq.create({
+      request: {
+        scanId: query.scanId,
+        quantId: query.quantId,
+        expressionId: query.exprId,
+        roiId: query.roiId,
+        units: query.units, 
+      }
+    })).pipe(
+      switchMap(resp => {
+        console.info(`  >> Expression output request for ${query.exprId} returned key=${resp.key}, jobId=${resp.jobId}`);
+
+        if (!resp.jobId || resp.jobId.length <= 0) {
+          console.info(`  >> Expression output was available, queried right away`);
+
+          // Query it right away
+          const obs = this.getDataWithMemoisation(query, allowAnyResponse, resp.key);
+
+          // Add to our in-flux cache
+          this._inFluxSingleQueryResultCache.set(resp.key, obs); // Make sure any obs going in here has shareReplay in its pipe
+          return obs;
+        }
+
+        // It's not available, so it's being calculated. We need to wait for an update message saying the job with the given key has completed!
+        // Here we wait for that and query when that's happened...
+        console.info(`  >> Expression output was NOT available, waiting for job ${resp.jobId} to complete...`);
+        return this._dataService.waitForJobCompletion(resp.jobId).pipe(
+          switchMap(jobStatus => {
+            console.info(`  >> Expression output job ${resp.jobId} completed, querying memoised output...`);
+            if (jobStatus.jobId != resp.jobId) {
+              throw new Error(`Received incorrect job id when waiting on expression outputs. Expected ${resp.jobId}, got ${jobStatus.jobId}`)
+            }
+
+            if (jobStatus.status != JobStatus_Status.COMPLETE) {
+              throw new Error("Job failed to complete: " + jobStatus.message)
+            }
+
+            return this.getDataWithMemoisation(query, allowAnyResponse, resp.key).pipe(
+              catchError(err => {
+                console.error(httpErrorToString(err, "Failed to retrieve memoised expression output"));
+                throw err;
+              })
+            );
+          }),
+          catchError(err => {
+            console.error(httpErrorToString(err, "Error requesting expression output after notification that it's available"));
+            throw err;
+          })
+        )
+      }
+    ));
+  }
+
+  private getMemoisedData(query: DataSourceParams, allowAnyResponse: boolean): Observable<DataQueryResult> {
     // Here we have our first level of caching. This is because a widget can be re-inited/updated due to many things
     // such as UI refresh/colours or settings loading, etc. We don't want each to trigger a whole new run of an
     // expression, so check if we already have an observable we can return for this


### PR DESCRIPTION
…up one query per call. This now gets the result and if it's not available, we wait for the result to singal it's completed as a JobListUpd, then query it via memoisation